### PR TITLE
Native Distribution tutorial corrections

### DIFF
--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -122,7 +122,7 @@ compose.desktop {
             packageName = "ExampleApp"
             version = "0.1-SNAPSHOT"
             description = "Compose Example App"
-            copyright = project.file("LICENSE.txt").readText()
+            copyright = "© 2020 My Name. All rights reserved."
             vendor = "Example vendor"
         }
     }
@@ -197,14 +197,16 @@ The app icon needs to be provided in OS-specific formats:
 ```kotlin
 compose.desktop {
     application {
-        macOS {
-            iconFile.set(project.file("icon.icns"))
-        }
-        windows {
-            iconFile.set(project.file("icon.ico"))
-        }
-        linux {
-            iconFile.set(project.file("icon.png"))
+        nativeDistributions {
+            macOS {
+                iconFile.set(project.file("icon.icns"))
+            }
+            windows {
+                iconFile.set(project.file("icon.ico"))
+            }
+            linux {
+                iconFile.set(project.file("icon.png"))
+            }
         }
     }
 }


### PR DESCRIPTION
Minor changes to the Native Distributions tutorial.

These were tested on Ubuntu 18.04 with Oracle JDK 15.

1. When loading a `LICENSE.txt` file (say MIT), jpackage will crash with a message saying that copyright is not a valid option. This can be confusing to the user since it is in fact a valid option.  jpackage is expecting a single line of text.

2. The icon section needs to be nested inside of the `nativeDistributions` section or gradle will fail to compile, saying that the DSL is invalid.  Although the icon did not show up in software center, it did show up in the application menu post-install.
