### PR TITLE
Support Gradle's Groovy DSL

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -5,6 +5,7 @@ package org.jetbrains.compose
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.ExtensionAware
 import org.jetbrains.compose.desktop.DesktopExtension
 import org.jetbrains.compose.desktop.application.internal.configureApplicationImpl
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
@@ -16,6 +17,16 @@ class ComposePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val composeExtension = project.extensions.create("compose", ComposeExtension::class.java)
         val desktopExtension = composeExtension.extensions.create("desktop", DesktopExtension::class.java)
+
+        if (!project.buildFile.endsWith(".gradle.kts")) {
+            // add compose extension for Groovy DSL to work
+            project.dependencies.extensions.add("compose", Dependencies)
+            project.plugins.withId("org.jetbrains.kotlin.multiplatform") {
+                (project.extensions.getByName("kotlin") as? ExtensionAware)?.apply {
+                    extensions.add("compose", Dependencies)
+                }
+            }
+        }
 
         project.afterEvaluate {
             if (desktopExtension._isApplicationInitialized) {


### PR DESCRIPTION
Before this change, the following Groovy DSL code would not work:
```
dependency {
  implementation compose.desktop.currentOS
}

// or

kotlin {
    jvm { withJava() }
    sourceSets {
        named("jvmMain") {
            dependencies {
                implementation(compose.desktop.currentOs)
            }
        }
    }
}
```