### PR TITLE
TodoApp. Update libraries.

### DIFF
--- a/examples/todoapp/build.gradle.kts
+++ b/examples/todoapp/build.gradle.kts
@@ -8,7 +8,5 @@ allprojects {
         jcenter()
         mavenLocal()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://dl.bintray.com/arkivanov/maven")
-        maven("https://dl.bintray.com/badoo/maven")
     }
 }

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -45,7 +45,7 @@ object Deps {
         }
 
         object Decompose {
-            private const val VERSION = "0.1.3"
+            private const val VERSION = "0.1.4"
             const val decompose = "com.arkivanov.decompose:decompose:$VERSION"
             const val decomposeIosX64 = "com.arkivanov.decompose:decompose-iosx64:$VERSION"
             const val decomposeIosArm64 = "com.arkivanov.decompose:decompose-iosarm64:$VERSION"
@@ -55,7 +55,7 @@ object Deps {
 
     object Badoo {
         object Reaktive {
-            private const val VERSION = "1.1.18"
+            private const val VERSION = "1.1.19"
             const val reaktive = "com.badoo.reaktive:reaktive:$VERSION"
             const val reaktiveTesting = "com.badoo.reaktive:reaktive-testing:$VERSION"
             const val utils = "com.badoo.reaktive:utils:$VERSION"

--- a/examples/todoapp/common/edit/src/commonMain/kotlin/example/todo/common/edit/integration/TodoEditImpl.kt
+++ b/examples/todoapp/common/edit/src/commonMain/kotlin/example/todo/common/edit/integration/TodoEditImpl.kt
@@ -3,6 +3,7 @@ package example.todo.common.edit.integration
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.operator.map
+import com.badoo.reaktive.base.invoke
 import example.todo.common.edit.TodoEdit
 import example.todo.common.edit.TodoEdit.Dependencies
 import example.todo.common.edit.TodoEdit.Model
@@ -37,6 +38,6 @@ internal class TodoEditImpl(
     }
 
     override fun onCloseClicked() {
-        editOutput.onNext(Output.Finished)
+        editOutput(Output.Finished)
     }
 }

--- a/examples/todoapp/common/main/src/commonMain/kotlin/example/todo/common/main/integration/TodoMainImpl.kt
+++ b/examples/todoapp/common/main/src/commonMain/kotlin/example/todo/common/main/integration/TodoMainImpl.kt
@@ -3,6 +3,7 @@ package example.todo.common.main.integration
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.decompose.value.operator.map
+import com.badoo.reaktive.base.invoke
 import example.todo.common.main.TodoMain
 import example.todo.common.main.TodoMain.Dependencies
 import example.todo.common.main.TodoMain.Model
@@ -28,7 +29,7 @@ internal class TodoMainImpl(
     override val models: Value<Model> = store.asValue().map(stateToModel)
 
     override fun onItemClicked(id: Long) {
-        mainOutput.onNext(Output.Selected(id = id))
+        mainOutput(Output.Selected(id = id))
     }
 
     override fun onItemDoneChanged(id: Long, isDone: Boolean) {


### PR DESCRIPTION
- Updated Decompose to `0.1.4`
- Updated Reaktive to `1.1.19`
- Removed `badoo` and `arkivanov` Bintray repositories, since they are now synchronized with JCenter
