### PR TITLE
Replace deprecated method call

### DIFF
--- a/examples/todoapp/common/main/src/commonTest/kotlin/example/todo/common/main/store/TestTodoMainStoreDatabase.kt
+++ b/examples/todoapp/common/main/src/commonTest/kotlin/example/todo/common/main/store/TestTodoMainStoreDatabase.kt
@@ -30,7 +30,7 @@ internal class TestTodoMainStoreDatabase : TodoMainStoreProvider.Database {
 
     override fun add(text: String): Completable =
         completableFromFunction {
-            val id = items.maxBy(TodoItem::id)?.id?.inc() ?: 1L
+            val id = items.maxByOrNull(TodoItem::id)?.id?.inc() ?: 1L
             this.items += TodoItem(id = id, order = id, text = text)
         }
 


### PR DESCRIPTION
gets rid of this warning:

`w: /home/ligi/git/3rd/compose-jb/examples/todoapp/common/main/src/commonTest/kotlin/example/todo/common/main/store/TestTodoMainStoreDatabase.kt: (33, 28): 'maxBy((T) -> R): T?' is deprecated. Use maxByOrNull instead.`
