### PR TITLE
Normalize all file properties on Windows

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/cliArgUtils.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/cliArgUtils.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.compose.desktop.application.internal
 
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 import java.io.File
 
@@ -26,7 +27,11 @@ internal fun <T : Any?> MutableCollection<String>.cliArg(
 
 private fun <T : Any?> defaultToString(): (T) -> String =
     {
-        val asString = if (it is File) it.normalizedPath() else it.toString()
+        val asString = when (it) {
+            is FileSystemLocation -> it.asFile.normalizedPath()
+            is File -> it.normalizedPath()
+            else -> it.toString()
+        }
         "\"$asString\""
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJLinkTask.kt
@@ -41,7 +41,7 @@ abstract class AbstractJLinkTask : AbstractJvmToolOperationTask("jlink") {
         cliArg("--no-header-files", noHeaderFiles)
         cliArg("--no-man-pages", noManPages)
         cliArg("--strip-native-commands", stripNativeCommands)
-        cliArg("--compress", compressionLevel.orNull?.id )
+        cliArg("--compress", compressionLevel.orNull?.id)
 
         cliArg("--output", destinationDir)
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -163,12 +163,12 @@ abstract class AbstractJPackageTask @Inject constructor(
         cliArg("--input", tmpDir)
         cliArg("--type", targetFormat.id)
 
-        cliArg("--dest", destinationDir.ioFile)
+        cliArg("--dest", destinationDir)
         cliArg("--verbose", verbose)
 
         cliArg("--install-dir", installationPath)
-        cliArg("--license-file", licenseFile.ioFileOrNull)
-        cliArg("--icon", iconFile.ioFileOrNull)
+        cliArg("--license-file", licenseFile)
+        cliArg("--icon", iconFile)
 
         cliArg("--name", packageName)
         cliArg("--description", packageDescription)
@@ -200,7 +200,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                 cliArg("--mac-package-name", macPackageName)
                 cliArg("--mac-bundle-signing-prefix", macBundleSigningPrefix)
                 cliArg("--mac-sign", macSign)
-                cliArg("--mac-signing-keychain", macSigningKeychain.ioFileOrNull)
+                cliArg("--mac-signing-keychain", macSigningKeychain)
                 cliArg("--mac-signing-key-user-name", macSigningKeyUserName)
             }
             OS.Windows -> {


### PR DESCRIPTION
Previously the `--output` argument of the jlink task was not normalized.

Fixes #248