### PR TITLE
fix(example): modify JetIssues's android app title

### DIFF
--- a/examples/issues/android/src/main/res/values/strings.xml
+++ b/examples/issues/android/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">IDE</string>
+    <string name="app_name">JetIssues</string>
 </resources>


### PR DESCRIPTION
## Overview

- Just noticed example `JetIssues` app uses `IDE` as an application's title on Android platform, this PR addresses that.

## Screenshot

| Before |  After |
:-------------------------:|:-------------------------:
<img width="150" alt="Screen Shot 2021-01-24 at 19 07 58" src="https://user-images.githubusercontent.com/471318/105627269-45cc4200-5e79-11eb-873e-26a8faeb4bd7.png">|<img width="150" alt="Screen Shot 2021-01-24 at 19 09 59" src="https://user-images.githubusercontent.com/471318/105627273-4bc22300-5e79-11eb-827f-732cb663bb1c.png">

