### PR TITLE
Filter out non-jar files in runtime classpath

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -125,7 +125,7 @@ internal fun AbstractJPackageTask.configurePackagingTask(
 
     app._configurationSource?.let { configSource ->
         dependsOn(configSource.jarTaskName)
-        files.from(configSource.runtimeClasspath)
+        files.from(configSource.runtimeClasspath(project))
         launcherMainJar.set(app.mainJar.orElse(configSource.jarTask(project).flatMap { it.archiveFile }))
     }
 
@@ -188,7 +188,7 @@ private fun JavaExec.configureRunTask(app: Application) {
 
     app._configurationSource?.let { configSource ->
         dependsOn(configSource.jarTaskName)
-        cp.from(configSource.runtimeClasspath)
+        cp.from(configSource.runtimeClasspath(project))
     }
 
     classpath = cp
@@ -207,7 +207,7 @@ private fun Jar.configurePackageUberJarForCurrentOS(app: Application) {
 
         app._configurationSource?.let { configSource ->
             dependsOn(configSource.jarTaskName)
-            from(flattenJars(configSource.runtimeClasspath))
+            from(flattenJars(configSource.runtimeClasspath(project)))
         }
 
         app.mainClass?.let { manifest.attributes["Main-Class"] = it }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/DesktopApplicationTest.kt
@@ -57,7 +57,7 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             OS.Windows -> "msi"
             OS.MacOS -> "dmg"
         }
-        file("build/compose/binaries/main/$ext/simple-1.0.$ext")
+        file("build/compose/binaries/main/$ext/TestPackage-1.0.$ext")
             .checkExists()
         assertEquals(TaskOutcome.SUCCESS, result.task(":package${ext.capitalize()}")?.outcome)
         assertEquals(TaskOutcome.SUCCESS, result.task(":package")?.outcome)

--- a/gradle-plugins/compose/src/test/test-projects/application/jvm/src/main/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvm/src/main/kotlin/main.kt
@@ -1,1 +1,18 @@
-fun main() {}
+import androidx.compose.desktop.Window
+import androidx.compose.material.Text
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.*
+
+fun main() = Window {
+    val scope = rememberCoroutineScope()
+    var text by remember { mutableStateOf("Hello, World!") }
+
+    MaterialTheme {
+        Button(onClick = {
+            text = "Hello, Desktop!"
+        }) {
+            Text(text)
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
@@ -33,8 +33,29 @@ compose.desktop {
     application {
         mainClass = "MainKt"
         nativeDistributions {
-            version = "1.0"
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+
+            version = "1.0"
+            packageName = "TestPackage"
+            description = "Test description"
+            copyright = "Test Copyright Holder"
+            vendor = "Test Vendor"
+
+            linux {
+                shortcut = true
+                packageName = "compose"
+                debMaintainer = "example@example.com"
+                menuGroup = "menu-group"
+            }
+            windows {
+                console = true
+                dirChooser = true
+                perUserInstall = true
+                shortcut = true
+                menu = true
+                menuGroup = "compose"
+                upgradeUuid = "2d6ff464-75be-40ad-a256-56420b9cc374"
+            }
         }
     }
 }


### PR DESCRIPTION
WiX linker fails to find class files of inlined functions for some reason
(maybe because of '$' character in name or long paths)

Fixes #196