### PR TITLE
Updates the intelliJPlugin example with currently IDEA Theme colors

### DIFF
--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/Theme.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/Theme.kt
@@ -5,17 +5,14 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import com.jetbrains.compose.theme.intellij.SwingColor
 
 private val DarkGreenColorPalette = darkColors(
     primary = green200,
     primaryVariant = green700,
     secondary = teal200,
-    background = Color.Black,
-    surface = Color(74, 74, 74),
     onPrimary = Color.Black,
     onSecondary = Color.White,
-    onBackground = Color.White,
-    onSurface = Color.White,
     error = Color.Red,
 )
 
@@ -23,11 +20,7 @@ private val LightGreenColorPalette = lightColors(
     primary = green500,
     primaryVariant = green700,
     secondary = teal200,
-    background = Color.White,
-    surface = Color.White,
     onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
     onSurface = Color.Black
 )
 
@@ -39,7 +32,12 @@ fun WidgetTheme(
     val colors = if (darkTheme) DarkGreenColorPalette else LightGreenColorPalette
 
     MaterialTheme(
-        colors = colors,
+        colors = colors.copy(
+            background = SwingColor.background,
+            onBackground = SwingColor.onBackground,
+            surface = SwingColor.background,
+            onSurface = SwingColor.onBackground,
+        ),
         typography = typography,
         shapes = shapes,
         content = content

--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/Theme.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/Theme.kt
@@ -30,13 +30,14 @@ fun WidgetTheme(
     content: @Composable() () -> Unit,
 ) {
     val colors = if (darkTheme) DarkGreenColorPalette else LightGreenColorPalette
+    val swingColor = SwingColor()
 
     MaterialTheme(
         colors = colors.copy(
-            background = SwingColor.background,
-            onBackground = SwingColor.onBackground,
-            surface = SwingColor.background,
-            onSurface = SwingColor.onBackground,
+            background = swingColor.background,
+            onBackground = swingColor.onBackground,
+            surface = swingColor.background,
+            onSurface = swingColor.onBackground,
         ),
         typography = typography,
         shapes = shapes,

--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/SwingColor.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/SwingColor.kt
@@ -1,0 +1,35 @@
+package com.jetbrains.compose.theme.intellij
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
+import javax.swing.UIManager
+import java.awt.Color as AWTColor
+
+interface SwingColor {
+    companion object : SwingColor by SwingColorImpl
+
+    val background: Color
+    val onBackground: Color
+}
+
+object SwingColorImpl : SwingColor {
+    private val _backgroundState: MutableState<Color> = mutableStateOf(getBackground)
+    private val _onBackgroundState: MutableState<Color> = mutableStateOf(getOnBackground)
+
+    override val background: Color get() = _backgroundState.value
+    override val onBackground: Color get() = _onBackgroundState.value
+
+    private const val BACKGROUND_KEY = "Panel.background"
+    private const val ON_BACKGROUND_KEY = "Panel.foreground"
+
+    private val getBackground get() = UIManager.getColor(BACKGROUND_KEY).asComposeColor
+    private val getOnBackground get() = UIManager.getColor(ON_BACKGROUND_KEY).asComposeColor
+
+    internal fun updateCurrentColors() {
+        _backgroundState.value = getBackground
+        _onBackgroundState.value = getOnBackground
+    }
+
+    private val AWTColor.asComposeColor: Color get() = Color(red, green, blue, alpha)
+}

--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/SwingColor.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/SwingColor.kt
@@ -1,35 +1,61 @@
 package com.jetbrains.compose.theme.intellij
 
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.Color
+import com.intellij.ide.ui.LafManagerListener
+import com.intellij.openapi.application.ApplicationManager
 import javax.swing.UIManager
 import java.awt.Color as AWTColor
 
 interface SwingColor {
-    companion object : SwingColor by SwingColorImpl
-
     val background: Color
     val onBackground: Color
 }
 
-object SwingColorImpl : SwingColor {
-    private val _backgroundState: MutableState<Color> = mutableStateOf(getBackground)
-    private val _onBackgroundState: MutableState<Color> = mutableStateOf(getOnBackground)
+@Composable
+fun SwingColor(): SwingColor {
+    val swingColor = remember { SwingColorImpl() }
+
+    val messageBus = remember {
+        ApplicationManager.getApplication().messageBus.connect()
+    }
+
+    remember(messageBus) {
+        messageBus.subscribe(
+            LafManagerListener.TOPIC,
+            ThemeChangeListener(swingColor::updateCurrentColors)
+        )
+    }
+
+    DisposableEffect(messageBus) {
+        onDispose {
+            messageBus.disconnect()
+        }
+    }
+
+    return swingColor
+}
+
+private class SwingColorImpl : SwingColor {
+    private val _backgroundState: MutableState<Color> = mutableStateOf(getBackgroundColor)
+    private val _onBackgroundState: MutableState<Color> = mutableStateOf(getOnBackgroundColor)
 
     override val background: Color get() = _backgroundState.value
     override val onBackground: Color get() = _onBackgroundState.value
 
-    private const val BACKGROUND_KEY = "Panel.background"
-    private const val ON_BACKGROUND_KEY = "Panel.foreground"
+    private val getBackgroundColor get() = getColor(BACKGROUND_KEY)
+    private val getOnBackgroundColor get() = getColor(ON_BACKGROUND_KEY)
 
-    private val getBackground get() = UIManager.getColor(BACKGROUND_KEY).asComposeColor
-    private val getOnBackground get() = UIManager.getColor(ON_BACKGROUND_KEY).asComposeColor
-
-    internal fun updateCurrentColors() {
-        _backgroundState.value = getBackground
-        _onBackgroundState.value = getOnBackground
+    fun updateCurrentColors() {
+        _backgroundState.value = getBackgroundColor
+        _onBackgroundState.value = getOnBackgroundColor
     }
 
     private val AWTColor.asComposeColor: Color get() = Color(red, green, blue, alpha)
+    private fun getColor(key: String): Color = UIManager.getColor(key).asComposeColor
+
+    companion object {
+        private const val BACKGROUND_KEY = "Panel.background"
+        private const val ON_BACKGROUND_KEY = "Panel.foreground"
+    }
 }

--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/ThemeChangeListener.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/ThemeChangeListener.kt
@@ -1,0 +1,11 @@
+package com.jetbrains.compose.theme.intellij
+
+import com.intellij.ide.ui.LafManager
+import com.intellij.ide.ui.LafManagerListener
+
+class ThemeChangeListener : LafManagerListener {
+    override fun lookAndFeelChanged(source: LafManager) {
+        SwingColorImpl.updateCurrentColors()
+    }
+}
+

--- a/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/ThemeChangeListener.kt
+++ b/examples/intelliJPlugin/src/main/kotlin/com/jetbrains/compose/theme/intellij/ThemeChangeListener.kt
@@ -3,9 +3,11 @@ package com.jetbrains.compose.theme.intellij
 import com.intellij.ide.ui.LafManager
 import com.intellij.ide.ui.LafManagerListener
 
-class ThemeChangeListener : LafManagerListener {
+internal class ThemeChangeListener(
+    val updateColors: () -> Unit
+) : LafManagerListener {
     override fun lookAndFeelChanged(source: LafManager) {
-        SwingColorImpl.updateCurrentColors()
+        updateColors()
     }
 }
 

--- a/examples/intelliJPlugin/src/main/resources/META-INF/plugin.xml
+++ b/examples/intelliJPlugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,10 @@ A plugin demonstrates Jetpack compose capabilities on IntelliJ Platform
         <!-- Add your extensions here -->
     </extensions>
 
+    <applicationListeners>
+        <listener class="com.jetbrains.compose.theme.intellij.ThemeChangeListener" topic="com.intellij.ide.ui.LafManagerListener" />
+    </applicationListeners>
+
     <actions>
         <!-- Add your actions here -->
         <action id="com.jetbrains.compose.ComposeDemoAction" class="com.jetbrains.compose.ComposeDemoAction"

--- a/examples/intelliJPlugin/src/main/resources/META-INF/plugin.xml
+++ b/examples/intelliJPlugin/src/main/resources/META-INF/plugin.xml
@@ -15,10 +15,6 @@ A plugin demonstrates Jetpack compose capabilities on IntelliJ Platform
         <!-- Add your extensions here -->
     </extensions>
 
-    <applicationListeners>
-        <listener class="com.jetbrains.compose.theme.intellij.ThemeChangeListener" topic="com.intellij.ide.ui.LafManagerListener" />
-    </applicationListeners>
-
     <actions>
         <!-- Add your actions here -->
         <action id="com.jetbrains.compose.ComposeDemoAction" class="com.jetbrains.compose.ComposeDemoAction"


### PR DESCRIPTION
This pull request change the example of the IntelliJ Plugin to use the currently `background` and `foreground` colors from IDEA Theme.

It also listens to `com.intellij.ide.ui.LafManagerListener` in order to update the state from `background` and `onBackground`.

![image](https://user-images.githubusercontent.com/29736164/107100492-45c22f80-67f3-11eb-84c8-69742222e18e.png)

Example using theme **Dark Purple**
