### PR TITLE
fix(doc): Fix the destination of the 'Signing & notarization on macOS' readme link

### DIFF
--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -78,7 +78,7 @@ to run such applications will be faced with an error like this:
 
 ![](attrs-error.png)
 
-See [our tutorial](tutorials/Signing_and_notarization_on_macOS/README.md) 
+See [our tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
 on how to sign and notarize your application. 
 
 ## Customizing JDK version


### PR DESCRIPTION
Fix the link by using an "absolute" link instead of a relative one.

Current URL `tutorials/Signing_and_notarization_on_macOS/README.md` gives a `404` (goes there: [link](https://github.com/JetBrains/compose-jb/blob/master/tutorials/Native_distributions_and_local_execution/tutorials/Signing_and_notarization_on_macOS/README.md ))
New URL `/tutorials/Signing_and_notarization_on_macOS/README.md` gives the correct result (goes there:[link](https://github.com/JetBrains/compose-jb/blob/master/tutorials/Signing_and_notarization_on_macOS/README.md ))