### PR TITLE
Update Tutorial README.md as App unusable on Ubuntu with plugin version used in wizard tutorial

### DIFF
--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -31,7 +31,7 @@ packaging JDK 14 or later must be used.
 ![Create new project 3](screen5.png)
 
 ### Update the wizard plugin
-The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available by editing the build.gradle.kts file, finding and updating the version information as shown below. (In this example the latest versions were kotlin 1.4.30 and compose plugin version 0.3.0-build152. For the latest versions, see the JetBrains [Kotlin](https://kotlinlang.org/) site and the [compose-jb](https://github.com/JetBrains/compose-jb/tags) github site.)
+The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available by editing the build.gradle.kts file, finding and updating the version information as shown below. (In this example the latest version of the plugin was 0.3.0-build152 and a compatible version of kotlin was 1.4.30. For the latest versions, see the [compose-jb](https://github.com/JetBrains/compose-jb/tags) github site and the JetBrains [Kotlin](https://kotlinlang.org/) site.)
 ```
 plugins {
     kotlin("jvm") version "1.4.30"

--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -31,9 +31,7 @@ packaging JDK 14 or later must be used.
 ![Create new project 3](screen5.png)
 
 ### Update the wizard plugin
-The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available. 
-E.g. at time of writing that was kotlin 1.4.30 and compose plugin version 0.3.0-build152.
-Find and update this in the build.gradle.kts file.
+The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available by editing the build.gradle.kts file, finding and updating the version information as shown below. (In this example the latest versions were kotlin 1.4.30 and compose plugin version 0.3.0-build152. For the latest versions, see the JetBrains [Kotlin](https://github.com/JetBrains/kotlin/releases/tag/v1.4.30) and [compose-jb](https://github.com/JetBrains/compose-jb/tags) github sites.)
 ```
 plugins {
     kotlin("jvm") version "1.4.30"

--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -32,7 +32,7 @@ packaging JDK 14 or later must be used.
 
 ### Update the wizard plugin
 The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available. 
-E.g. at time of writing that wsa kotlin 1.4.30 and compose plugin version 0.3.0-build152.
+E.g. at time of writing that was kotlin 1.4.30 and compose plugin version 0.3.0-build152.
 Find and update this in the build.gradle.kts file.
 ```
 plugins {

--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -31,7 +31,7 @@ packaging JDK 14 or later must be used.
 ![Create new project 3](screen5.png)
 
 ### Update the wizard plugin
-The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available by editing the build.gradle.kts file, finding and updating the version information as shown below. (In this example the latest versions were kotlin 1.4.30 and compose plugin version 0.3.0-build152. For the latest versions, see the JetBrains [Kotlin](https://github.com/JetBrains/kotlin/releases/tag/v1.4.30) and [compose-jb](https://github.com/JetBrains/compose-jb/tags) github sites.)
+The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available by editing the build.gradle.kts file, finding and updating the version information as shown below. (In this example the latest versions were kotlin 1.4.30 and compose plugin version 0.3.0-build152. For the latest versions, see the JetBrains [Kotlin](https://kotlinlang.org/) site and the [compose-jb](https://github.com/JetBrains/compose-jb/tags) github site.)
 ```
 plugins {
     kotlin("jvm") version "1.4.30"


### PR DESCRIPTION
Following the Getting Started wizard tutorial on some Ubuntu 64bit configurations resulted in the app produced being basically non functional.

The compose plugin version created from the IDE wizard resulted in extremely slow behaviour of the app. Clicking the button would take multiple seconds for the button to update whereas it is expected to be instantaneous.

Updating the plugin version made the example apps functional.

This adds a suggestion to the tutorial that after using the wizard you should update the plugin version.