### PR TITLE
Gradle plugin. Replace 'androidx.compose' artifacts by 'org.jetbrains.compose' artifacts.

### DIFF
--- a/gradle-plugins/buildSrc/build.gradle.kts
+++ b/gradle-plugins/buildSrc/build.gradle.kts
@@ -9,4 +9,6 @@ repositories {
 dependencies {
     compileOnly(gradleApi())
     implementation(kotlin("stdlib"))
+    implementation("io.ktor:ktor-client-core:1.5.1")
+    implementation("io.ktor:ktor-client-cio:1.5.1")
 }

--- a/gradle-plugins/buildSrc/src/main/kotlin/printAllAndroidxReplacements.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/printAllAndroidxReplacements.kt
@@ -6,16 +6,17 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
+import org.gradle.api.Project
 
 private const val libsRepo = "https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/"
-private const val version = "0.3.0-build154"
 private val exceptions = listOf(
     "desktop:desktop",
     "compose-full",
     "compose-gradle-plugin"
 )
 
-fun printAllAndroidxReplacements() = runBlocking {
+fun Project.printAllAndroidxReplacements() = runBlocking {
+    val version = BuildProperties.composeVersion(project)
     HttpClient().use { client ->
         client
             .allRecursiveFolders(libsRepo)

--- a/gradle-plugins/buildSrc/src/main/kotlin/printAllAndroidxReplacements.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/printAllAndroidxReplacements.kt
@@ -1,0 +1,66 @@
+import io.ktor.client.*
+import io.ktor.client.request.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+
+private const val libsRepo = "https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/"
+private const val version = "0.3.0-build154"
+private val exceptions = listOf(
+    "desktop:desktop",
+    "compose-full",
+    "compose-gradle-plugin"
+)
+
+fun printAllAndroidxReplacements() = runBlocking {
+    HttpClient().use { client ->
+        client
+            .allRecursiveFolders(libsRepo)
+            .map { it.removePrefix(libsRepo).removeSuffix("/") }
+            .filter { it.endsWith(version) }
+            .map { it.removeSuffix(version).removeSuffix("/") }
+            .map { it.replace("/", ":") }
+            .filter { !it.endsWith("-android") }
+            .filter { !it.endsWith("-android-debug") }
+            .filter { !it.endsWith("-android-release") }
+            .filter { !it.endsWith("-metadata") }
+            .filter { !it.endsWith("-desktop") }
+            .filter { !it.contains("-jvm") }
+            .filter { !exceptions.contains(it) }
+            .collect {
+                require(isMavenCoordsValid(it)) {
+                    "module name isn't valid: $it"
+                }
+                println("it.replaceAndroidx(\"androidx.compose.$it\", \"org.jetbrains.compose.$it\")")
+            }
+    }
+}
+
+private fun isMavenCoordsValid(coords: String) = coords.count { it == ':' } == 1
+
+private fun HttpClient.allRecursiveFolders(
+    url: String
+): Flow<String> = flow {
+    require(url.endsWith("/"))
+    val response = get<String>(url)
+    val folders = parseFolders(response)
+    for (folder in folders) {
+        emit("$url$folder/")
+    }
+    for (folder in folders.filter(String::isMavenPart)) {
+        allRecursiveFolders("$url$folder/").collect(::emit)
+    }
+}
+
+private fun parseFolders(
+    htmlResponse: String
+): Sequence<String> = Regex("title=\"(.*?)\"")
+    .findAll(htmlResponse)
+    .map { it.groupValues[1] }
+    .filter { it.endsWith("/") && it != "../" }
+    .map { it.removeSuffix("/") }
+
+private fun String.isMavenPart() = all { it.isLetterOrDigit() || it == '-' }

--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -101,3 +101,7 @@ fun Test.configureTest(gradleVersion: String) {
 tasks.named("check") {
     dependsOn(testMinGradleVersion)
 }
+
+task("printAllAndroidxReplacements") {
+    doLast { printAllAndroidxReplacements() }
+}

--- a/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/272