### PR TITLE
Include java.logging module by default

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
@@ -21,7 +21,7 @@ open class NativeDistributions @Inject constructor(
         set(layout.buildDirectory.dir("compose/binaries"))
     }
 
-    var modules = arrayListOf("java.desktop")
+    var modules = arrayListOf("java.desktop", "java.logging")
     fun modules(vararg modules: String) {
         this.modules.addAll(modules.toList())
     }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/DesktopApplicationTest.kt
@@ -113,4 +113,12 @@ class DesktopApplicationTest : GradlePluginTestBase() {
             check.logContains("Called lib2#util()")
         }
     }
+
+    @Test
+    fun testJavaLogger() = with(testProject(TestProjects.javaLogger)) {
+        gradle(":runDistributable").build().checks { check ->
+            check.taskOutcome(":runDistributable", TaskOutcome.SUCCESS)
+            check.logContains("Compose Gradle plugin test log warning!")
+        }
+    }
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
@@ -5,4 +5,5 @@ object TestProjects {
     const val mpp = "application/mpp"
     const val jvmKotlinDsl = "application/jvmKotlinDsl"
     const val moduleClashCli = "application/moduleClashCli"
+    const val javaLogger = "application/javaLogger"
 }

--- a/gradle-plugins/compose/src/test/test-projects/application/javaLogger/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/javaLogger/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.compose"
+}
+
+repositories {
+    google()
+    mavenCentral()
+    jcenter()
+    maven {
+        url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation compose.desktop.currentOs
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/javaLogger/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/javaLogger/settings.gradle
@@ -1,0 +1,11 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.compose' version 'COMPOSE_VERSION_PLACEHOLDER'
+    }
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+rootProject.name = "javaLogger"

--- a/gradle-plugins/compose/src/test/test-projects/application/javaLogger/src/main/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/javaLogger/src/main/kotlin/main.kt
@@ -1,0 +1,3 @@
+fun main() {
+    java.util.logging.Logger.getAnonymousLogger().warning("Compose Gradle plugin test log warning!")
+}


### PR DESCRIPTION
It is probably frequently needed and relatively small
(the inclusion increases final app size by ~200 kb),
so it can be included by default

Fixes #401