### PR TITLE
Fix android build in codeviewer example

### DIFF
--- a/examples/imageviewer/common/build.gradle.kts
+++ b/examples/imageviewer/common/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
         }
         named("androidMain") {
             dependencies {
-                api("androidx.appcompat:appcompat:1.1.0")
+                api("androidx.appcompat:appcompat:1.3.0-beta01")
                 api("androidx.core:core-ktx:1.3.1")
                 implementation("io.ktor:ktor-client-cio:1.4.1")
             }


### PR DESCRIPTION
Latest compose version requires a newer appcompat version, see:
https://github.com/JetBrains/compose-jb/issues/440