### PR TITLE
Wordsmith swing interop API description

### DIFF
--- a/tutorials/Swing_Integration/README.md
+++ b/tutorials/Swing_Integration/README.md
@@ -149,7 +149,7 @@ fun Counter(text: String, counter: MutableState<Int>) {
 
 ## Adding a Swing component to CFD composition using SwingPanel.
 
-SwingPanel lets you create a UI using Swing components in a Compose-based UI. To achieve this you need to create Swing component and pass it as a parameter to SwingPanel.
+SwingPanel lets you create a UI using Swing in a Compose-based UI. To achieve this you need to create Swing `JComponent` in the `factory` parameter of `SwingPanel`.
 
 ```kotlin
 import androidx.compose.desktop.SwingPanel


### PR DESCRIPTION
We've been seeing an antipattern where people are literally "passing a view/jcomponent" into the interop API by merely referencing the native object in the factory lambda.  This usage is very much an antipattern.  Wordsmithing a bit to avoid putting that idea into people's minds.