### PR TITLE
Fix task validation errors on Gradle 7

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractCheckNativeDistributionRuntime.kt
@@ -16,7 +16,6 @@ private const val MIN_JAVA_RUNTIME_VERSION = 15
 
 @CacheableTask
 abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTask() {
-    @get:PathSensitive(PathSensitivity.ABSOLUTE)
     @get:Input
     val javaHome: Property<String> = objects.notNullProperty()
 
@@ -26,11 +25,9 @@ abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTa
     @get:LocalState
     val workingDir: Provider<Directory> = project.layout.buildDirectory.dir("compose/tmp/$name")
 
-    @get:Internal
     private val javaExec: File
         get() = getTool("java")
 
-    @get:Internal
     private val javacExec: File
         get() = getTool("javac")
 
@@ -108,7 +105,7 @@ abstract class AbstractCheckNativeDistributionRuntime : AbstractComposeDesktopTa
                             printVersionAndHalt(System.getProperty("java.version"));
                         }
                     }
-                
+
                     private static void printVersionAndHalt(String version) {
                         System.out.println("$javaVersionPrefix" + version + "$javaVersionSuffix");
                         Runtime.getRuntime().exit(0);


### PR DESCRIPTION
Building with Gradle 7.0-milestone-3 results in task validation errors for the `checkRuntime` task:

<details>
<summary>Gradle log</summary>
<pre>FAILURE: Build failed with an exception.
* What went wrong:
Some problems were found with the configuration of task ':ui-demo:checkRuntime' (type 'AbstractCheckNativeDistributionRuntime').
  - Type 'AbstractCheckNativeDistributionRuntime' property 'javaExec' is private and annotated with @Internal.
    Reason: Annotations on private getters are ignored.
    Possible solutions:
      1. Make the getter public.
      2. Annotate the public version of the getter.
    Please refer to https://docs.gradle.org/7.0-milestone-3/userguide/validation_problems.html#private_getter_must_not_be_annotated for more details about this problem.
  - Type 'AbstractCheckNativeDistributionRuntime' property 'javaHome' is annotated with @PathSensitive but that is not allowed for 'Input' properties.
    Reason: This modifier is used in conjunction with a property of type 'Input' but this doesn't have semantics.
    Possible solution: Remove the '@PathSensitive' annotation.
    Please refer to https://docs.gradle.org/7.0-milestone-3/userguide/validation_problems.html#incompatible_annotations for more details about this problem.
  - Type 'AbstractCheckNativeDistributionRuntime' property 'javacExec' is private and annotated with @Internal.
    Reason: Annotations on private getters are ignored.
    Possible solutions:
      1. Make the getter public.
      2. Annotate the public version of the getter.
    Please refer to https://docs.gradle.org/7.0-milestone-3/userguide/validation_problems.html#private_getter_must_not_be_annotated for more details about this problem.</pre>
</details>

To fix these problems: 
- Remove the `@Internal` annotation from private properties
- Remove the `@PathSensitive` annotation from the `javaHome` property, as it is not a file or directory property.