### PR TITLE
Don't apply Compose compiler plugin to JS and Native compilations

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.compose
+
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.plugin.*
+
+class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
+    override fun getCompilerPluginId(): String =
+        "org.jetbrains.compose"
+
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
+        val targetPlatform = kotlinCompilation.target.platformType
+        return targetPlatform != KotlinPlatformType.js
+                && targetPlatform != KotlinPlatformType.native
+    }
+
+    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> =
+        kotlinCompilation.target.project.provider { emptyList() }
+
+    override fun getPluginArtifact(): SubpluginArtifact =
+        SubpluginArtifact(
+            groupId = "org.jetbrains.compose.compiler", artifactId = "compiler", version = composeVersion
+        )
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -13,7 +13,7 @@ import org.jetbrains.compose.desktop.application.internal.currentTarget
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-private val composeVersion get() = ComposeBuildConfig.composeVersion
+internal val composeVersion get() = ComposeBuildConfig.composeVersion
 
 class ComposePlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -30,17 +30,14 @@ class ComposePlugin : Plugin<Project> {
             }
         }
 
+        project.pluginManager.apply(ComposeCompilerKotlinSupportPlugin::class.java)
+
         project.afterEvaluate {
             if (desktopExtension._isApplicationInitialized) {
                 // If application object was not accessed in a script,
                 // we want to avoid creating tasks like package, run, etc. to avoid conflicts with other plugins
                 configureApplicationImpl(project, desktopExtension.application)
             }
-
-            project.dependencies.add(
-                "kotlinCompilerPluginClasspath",
-                "org.jetbrains.compose.compiler:compiler:$composeVersion"
-            )
         }
 
         fun ComponentModuleMetadataHandler.replaceAndroidx(original: String, replacement: String) {

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/GradlePluginTest.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.compose
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.jetbrains.compose.test.GradlePluginTestBase
+import org.jetbrains.compose.test.TestKotlinVersion
+import org.jetbrains.compose.test.TestProjects
+import org.jetbrains.compose.test.checks
+import org.junit.jupiter.api.Test
+
+class GradlePluginTest : GradlePluginTestBase() {
+    @Test
+    fun jsMppIsNotBroken() =
+        with(
+            testProject(
+                TestProjects.jsMpp,
+                testEnvironment = defaultTestEnvironment.copy(kotlinVersion = TestKotlinVersion.V1_5_20_dev_3226)
+            )
+        ) {
+            gradle(":compileKotlinJs").build().checks { check ->
+                check.taskOutcome(":compileKotlinJs", TaskOutcome.SUCCESS)
+            }
+        }
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/GradlePluginTestBase.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/GradlePluginTestBase.kt
@@ -7,6 +7,12 @@ abstract class GradlePluginTestBase {
     @TempDir
     lateinit var testWorkDir: File
 
-    fun testProject(name: String): TestProject =
-        TestProject(name, workingDir = testWorkDir)
+    val defaultTestEnvironment: TestEnvironment
+        get() = TestEnvironment(workingDir = testWorkDir)
+
+    fun testProject(
+        name: String,
+        testEnvironment: TestEnvironment = defaultTestEnvironment
+    ): TestProject =
+        TestProject(name, testEnvironment = testEnvironment)
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestKotlinVersion.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestKotlinVersion.kt
@@ -1,0 +1,8 @@
+package org.jetbrains.compose.test
+
+@Suppress("EnumEntryName")
+enum class TestKotlinVersion(val versionString: String) {
+    // __KOTLIN_COMPOSE_VERSION__
+    Default("1.4.31"),
+    V1_5_20_dev_3226("1.5.20-dev-3226")
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
@@ -8,4 +8,5 @@ object TestProjects {
     const val javaLogger = "application/javaLogger"
     const val macOptions = "application/macOptions"
     const val optionsWithSpaces = "application/optionsWithSpaces"
+    const val jsMpp = "misc/jsMpp"
 }

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProperties.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProperties.kt
@@ -1,9 +1,6 @@
 package org.jetbrains.compose.test
 
 object TestProperties {
-    // __KOTLIN_COMPOSE_VERSION__
-    val kotlinVersion: String = "1.4.31"
-
     val composeVersion: String
         get() = System.getProperty("compose.plugin.version")!!
 

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/build.gradle
@@ -1,0 +1,33 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    id "org.jetbrains.kotlin.multiplatform"
+    id "org.jetbrains.compose"
+}
+
+repositories {
+    google()
+    mavenCentral()
+    jcenter()
+    maven { url "https://maven.pkg.jetbrains.space/public/p/compose/dev" }
+    maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+}
+
+kotlin {
+    js(IR) {
+        browser()
+    }
+    jvm {}
+
+    sourceSets {
+        named("commonMain") {
+        }
+        named("jsMain") {
+        }
+        named("jvmMain") {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+            }
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.multiplatform' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.compose' version 'COMPOSE_VERSION_PLACEHOLDER'
+    }
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+        maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
+    }
+}
+rootProject.name = "jsMpp"

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/commonMain/kotlin/platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/commonMain/kotlin/platform.kt
@@ -1,0 +1,1 @@
+expect fun getPlatformName(): String

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/jsMain/kotlin/platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/jsMain/kotlin/platform.kt
@@ -1,0 +1,1 @@
+actual fun getPlatformName(): String = "js"

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/jvmMain/kotlin/platform.kt
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/src/jvmMain/kotlin/platform.kt
@@ -1,0 +1,1 @@
+actual fun getPlatformName(): String = "jvm"


### PR DESCRIPTION
Resolves #352

The fix resolves the issue only for Kotlin compiler builds the following commit:
https://github.com/JetBrains/kotlin/commit/d023f09bd45e6b21fa341f8481521c9a21c8b924

See also https://youtrack.jetbrains.com/issue/KT-45020