### PR TITLE
Update README.md with image resource path

### DIFF
--- a/tutorials/Image_And_Icons_Manipulations/README.md
+++ b/tutorials/Image_And_Icons_Manipulations/README.md
@@ -20,7 +20,7 @@ import androidx.compose.ui.res.imageResource
 fun main() {
     Window {
         Image(
-            bitmap = imageResource("sample.png"), // ImageBitmap
+            bitmap = imageResource("images/sample.png"), // ImageBitmap
             contentDescription = "Sample",
             modifier = Modifier.fillMaxSize()
         )


### PR DESCRIPTION
The loading "images from resources" specifies that the image is placed in `resources/images` however the loading of the resource does not reflect this path.