### PR TITLE
Update to 0.4.0-build182 and get rid of jcenter

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -9,18 +9,17 @@ plugins {
     id("org.jetbrains.compose") version "0.2.0-build132"
     // __KOTLIN_COMPOSE_VERSION__
     kotlin("plugin.allopen") version "1.4.20"
-    id("kotlinx.benchmark") version "0.2.0-dev-20"
+    id("kotlinx.benchmark") version "0.3.0"
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-    maven("https://dl.bintray.com/kotlin/kotlinx")
 }
 
 dependencies {
     implementation(compose.desktop.currentOs)
-    implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:0.2.0-dev-20")
+    implementation("org.jetbrains.kotlinx:kotlinx.benchmark.runtime:0.3.0")
 }
 
 configure<AllOpenExtension> {

--- a/benchmarks/settings.gradle.kts
+++ b/benchmarks/settings.gradle.kts
@@ -2,6 +2,6 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-        maven("https://dl.bintray.com/kotlin/kotlinx")
+        mavenCentral()
     }
 }

--- a/cef/build.gradle.kts
+++ b/cef/build.gradle.kts
@@ -43,7 +43,7 @@ val cefUnZip = run {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     // temp
     maven("https://packages.jetbrains.team/maven/p/ui/dev")

--- a/ci/compose-uber-jar/build.gradle.kts
+++ b/ci/compose-uber-jar/build.gradle.kts
@@ -10,7 +10,6 @@ val properties = ComposeUberJarProperties()
 
 repositories {
     mavenCentral()
-    jcenter()
     maven(properties.composeRepoUrl)
 }
 

--- a/ci/compose-uber-jar/gradle.properties
+++ b/ci/compose-uber-jar/gradle.properties
@@ -1,3 +1,3 @@
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=0.4.0-build180
+compose.version=0.4.0-build182
 kotlin.code.style=official

--- a/components/build.gradle.kts
+++ b/components/build.gradle.kts
@@ -1,10 +1,10 @@
 buildscript {
     // __LATEST_COMPOSE_RELEASE_VERSION__
-    val composeVersion = System.getenv("COMPOSE_RELEASE_VERSION") ?: "0.4.0-build180"
+    val composeVersion = System.getenv("COMPOSE_RELEASE_VERSION") ?: "0.4.0-build182"
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/examples/codeviewer/build.gradle.kts
+++ b/examples/codeviewer/build.gradle.kts
@@ -3,13 +3,13 @@ buildscript {
         // TODO: remove after new build is published
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     dependencies {
         // __LATEST_COMPOSE_RELEASE_VERSION__
-        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build180")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build182")
         classpath("com.android.tools.build:gradle:4.0.1")
          // __KOTLIN_COMPOSE_VERSION__
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/examples/falling_balls/build.gradle.kts
+++ b/examples/falling_balls/build.gradle.kts
@@ -6,14 +6,13 @@ plugins {
     // __KOTLIN_COMPOSE_VERSION__
     kotlin("jvm") version "1.4.32"
     // __LATEST_COMPOSE_RELEASE_VERSION__
-    id("org.jetbrains.compose") version "0.4.0-build180"
+    id("org.jetbrains.compose") version "0.4.0-build182"
 }
 
 group = "me.user"
 version = "1.0"
 
 repositories {
-    jcenter()
     mavenCentral()
     maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
 }

--- a/examples/imageviewer/build.gradle.kts
+++ b/examples/imageviewer/build.gradle.kts
@@ -5,13 +5,13 @@ buildscript {
             includeModule("org.jetbrains.compose", "compose-gradle-plugin")
         }
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     dependencies {
         // __LATEST_COMPOSE_RELEASE_VERSION__
-        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build180")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build182")
         classpath("com.android.tools.build:gradle:4.0.1")
         // __KOTLIN_COMPOSE_VERSION__
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
@@ -22,7 +22,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/examples/intelliJPlugin/build.gradle.kts
+++ b/examples/intelliJPlugin/build.gradle.kts
@@ -5,14 +5,13 @@ plugins {
     java
     kotlin("jvm") version "1.4.32"
     // __LATEST_COMPOSE_RELEASE_VERSION__
-    id("org.jetbrains.compose") version "0.4.0-build180"
+    id("org.jetbrains.compose") version "0.4.0-build182"
 }
 
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
 repositories {
-    jcenter()
     mavenCentral()
     maven { url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev") }
 }

--- a/examples/issues/build.gradle.kts
+++ b/examples/issues/build.gradle.kts
@@ -3,13 +3,13 @@ buildscript {
         // TODO: remove after new build is published
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     dependencies {
         // __LATEST_COMPOSE_RELEASE_VERSION__
-        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build180")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build182")
         classpath("com.android.tools.build:gradle:4.0.1")
         // __KOTLIN_COMPOSE_VERSION__
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
@@ -20,7 +20,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/examples/todoapp/build.gradle.kts
+++ b/examples/todoapp/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 allprojects {
     repositories {
         google()
+        mavenCentral()
+        // todo: remove after https://github.com/badoo/Reaktive/issues/580 is resolved
         jcenter()
         mavenLocal()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")

--- a/examples/todoapp/buildSrc/build.gradle.kts
+++ b/examples/todoapp/buildSrc/build.gradle.kts
@@ -6,7 +6,7 @@ repositories {
     // TODO: remove after new build is published
     mavenLocal()
     google()
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 

--- a/examples/todoapp/buildSrc/buildSrc/build.gradle.kts
+++ b/examples/todoapp/buildSrc/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -12,7 +12,7 @@ object Deps {
 
         object Compose {
             // __LATEST_COMPOSE_RELEASE_VERSION__
-            private const val VERSION = "0.4.0-build180"
+            private const val VERSION = "0.4.0-build182"
             const val gradlePlugin = "org.jetbrains.compose:compose-gradle-plugin:$VERSION"
         }
     }

--- a/examples/widgetsgallery/build.gradle.kts
+++ b/examples/widgetsgallery/build.gradle.kts
@@ -3,13 +3,13 @@ buildscript {
         // TODO: remove after new build is published
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
     dependencies {
         // __LATEST_COMPOSE_RELEASE_VERSION__
-        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build180")
+        classpath("org.jetbrains.compose:compose-gradle-plugin:0.4.0-build182")
         classpath("com.android.tools.build:gradle:4.0.1")
         // __KOTLIN_COMPOSE_VERSION__
         classpath(kotlin("gradle-plugin", version = "1.4.32"))
@@ -19,7 +19,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -12,8 +12,7 @@ subprojects {
     version = BuildProperties.deployVersion(project)
 
     repositories {
-        maven("https://dl.bintray.com/kotlin/kotlin-dev")
-        jcenter()
+        mavenCentral()
         mavenLocal()
     }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/javaLogger/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/javaLogger/build.gradle
@@ -6,7 +6,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/jvmKotlinDsl/build.gradle.kts
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvmKotlinDsl/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 

--- a/gradle-plugins/compose/src/test/test-projects/application/macOptions/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/macOptions/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/moduleClashCli/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/moduleClashCli/build.gradle
@@ -7,7 +7,6 @@ subprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
         maven {
             url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
         }

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/optionsWithSpaces/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/optionsWithSpaces/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/application/unpackSkiko/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/unpackSkiko/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven {
         url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
     }

--- a/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/misc/jsMpp/build.gradle
@@ -8,7 +8,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    jcenter()
     maven { url "https://maven.pkg.jetbrains.space/public/p/compose/dev" }
     maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
 }

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -6,7 +6,7 @@ kotlin.code.style=official
 # unless overridden by COMPOSE_GRADLE_PLUGIN_COMPOSE_VERSION env var.
 #
 # __LATEST_COMPOSE_RELEASE_VERSION__
-compose.version=0.4.0-build180
+compose.version=0.4.0-build182
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.

--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://dl.bintray.com/kotlin/kotlin-dev")
     }
 }
 

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -14,7 +14,6 @@ version = properties("deploy.version")
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 intellij {

--- a/idea-plugin/examples/desktop-project/build.gradle.kts
+++ b/idea-plugin/examples/desktop-project/build.gradle.kts
@@ -7,11 +7,12 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.4")
     implementation(compose.desktop.currentOs)
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 }

--- a/templates/desktop-template/build.gradle.kts
+++ b/templates/desktop-template/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     // __KOTLIN_COMPOSE_VERSION__
     kotlin("jvm") version "1.4.32"
     // __LATEST_COMPOSE_RELEASE_VERSION__
-    id("org.jetbrains.compose") version (System.getenv("COMPOSE_TEMPLATE_COMPOSE_VERSION") ?: "0.4.0-build180")
+    id("org.jetbrains.compose") version (System.getenv("COMPOSE_TEMPLATE_COMPOSE_VERSION") ?: "0.4.0-build182")
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 

--- a/templates/multiplatform-template/build.gradle.kts
+++ b/templates/multiplatform-template/build.gradle.kts
@@ -1,12 +1,12 @@
 buildscript {
     // __LATEST_COMPOSE_RELEASE_VERSION__
-    val composeVersion = System.getenv("COMPOSE_TEMPLATE_COMPOSE_VERSION") ?: "0.4.0-build180"
+    val composeVersion = System.getenv("COMPOSE_TEMPLATE_COMPOSE_VERSION") ?: "0.4.0-build182"
 
     repositories {
         // TODO: remove after new build is published
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 
@@ -21,7 +21,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }

--- a/tools/replace.sh
+++ b/tools/replace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 COMPOSE_OLDVER=0.3.2
-COMPOSE_NEWVER=0.4.0-build180
+COMPOSE_NEWVER=0.4.0-build182
 find -E $ROOT  -regex '.*\.(kts|properties|kt)' -exec sed -i '' -e "s/$COMPOSE_OLDVER/$COMPOSE_NEWVER/g" {} \;
 APPCOMPAT_OLDVER=1.1.0
 APPCOMPAT_NEWVER=1.3.0-beta01

--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -22,7 +22,7 @@ Kotlin support in IDEA IDE starting with the version 2020.3 comes with the new p
 capable to create a Compose application automatically.
 
 Note that JDK must be at least JDK 11, and to use the native distribution
-packaging JDK 14 or later must be used.
+packaging JDK 15 or later must be used.
 
 ![Create new project 1](screen3.png)
 
@@ -32,11 +32,11 @@ packaging JDK 14 or later must be used.
 
 ### Update the wizard plugin
 
-The Сompose plugin version used in the wizard above may be not the last. Update the version of the plugin to the latest available by editing the `build.gradle.kts` file, finding and updating the version information as shown below. In this example the latest version of the plugin was 0.3.0-build152 and a compatible version of kotlin was 1.4.30. For the latest versions, see the [latest versions](https://github.com/JetBrains/compose-jb/tags) site and the [Kotlin](https://kotlinlang.org/) site.
+The Сompose plugin version used in the wizard above may be not the last. Update the version of the plugin to the latest available by editing the `build.gradle.kts` file, finding and updating the version information as shown below. In this example the latest version of the plugin was 0.4.0-build182 and a compatible version of kotlin was 1.4.32. For the latest versions, see the [latest versions](https://github.com/JetBrains/compose-jb/releases) site and the [Kotlin](https://kotlinlang.org/) site.
 ```
 plugins {
-    kotlin("jvm") version "1.4.30"
-    id("org.jetbrains.compose") version "0.3.0"
+    kotlin("jvm") version "1.4.32"
+    id("org.jetbrains.compose") version "0.4.0-build182"
 }
 ```
 
@@ -71,12 +71,12 @@ Then create `build.gradle.kts` with the following content:
 import org.jetbrains.compose.compose
 
 plugins {
-    kotlin("jvm") version "1.4.30"
-    id("org.jetbrains.compose") version "0.3.0"
+    kotlin("jvm") version "1.4.32"
+    id("org.jetbrains.compose") version "0.4.0-build182"
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
 }
 


### PR DESCRIPTION
The build `0.4.0-build182` upgrades `kotlinx-collections-immutable` library
(which is used by the compose runtime) to 0.3.4 available on maven central,
so most usages of sunsetting jcenter repo can be removed now.

Resolves #557