### PR TITLE
`falling_balls`: Use local density instead of setting `fillMaxHeight` to 0.5f

### DIFF
--- a/examples/falling_balls/src/main/kotlin/Game.kt
+++ b/examples/falling_balls/src/main/kotlin/Game.kt
@@ -8,9 +8,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.*
 import kotlin.random.Random
 
 class Game {
@@ -21,7 +20,7 @@ class Game {
     )
     private var startTime = 0L
 
-    var size by mutableStateOf(IntSize(0, 0))
+    var size by mutableStateOf(Pair(0.dp, 0.dp))
 
     var pieces = mutableStateListOf<PieceData>()
         private set
@@ -75,6 +74,7 @@ class Game {
 @Composable
 fun FallingBallsGame() {
     val game = remember { Game() }
+    val density = LocalDensity.current
     Column {
         Text(
             "Catch balls!${if (game.finished) " Game over!" else ""}",
@@ -110,9 +110,11 @@ fun FallingBallsGame() {
         if (game.started) {
             Box(modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(0.5f)
+                .fillMaxHeight()
                 .onSizeChanged {
-                    game.size = it
+                    with(density) {
+                        game.size = it.width.toDp() to it.height.toDp()
+                    }
                 }
             ) {
                 game.pieces.forEachIndexed { index, piece -> Piece(index, piece) }

--- a/examples/falling_balls/src/main/kotlin/Piece.kt
+++ b/examples/falling_balls/src/main/kotlin/Piece.kt
@@ -41,7 +41,7 @@ data class PieceData(val game: Game, val velocity: Float, val color: Color) {
     fun update(dt: Long) {
         if (clicked) return
         val delta = (dt / 1E8 * velocity).toFloat()
-        position = if (position < game.size.height) position + delta else 0f
+        position = if (position < game.size.second.value) position + delta else 0f
     }
 
     fun click() {


### PR DESCRIPTION
Previously, height was set to 0.5 to get the "vertical compression" of the play field (a difference caused by 2x pixel density). This PR adds explicit usage of pixel density instead.

Seems to me this is the "correcter" way of determining the height of the play field. Unfortunately, I could not find a nice container object for two `Dp`s (besides `DpOffset`), so using `Pair` for now. Let me know if you feel there's a better way / a `data class` would be preferred.