### PR TITLE
Simplify TodoApp example iOS framework export

### DIFF
--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -41,8 +41,6 @@ object Deps {
             const val rx = "com.arkivanov.mvikotlin:rx:$VERSION"
             const val mvikotlin = "com.arkivanov.mvikotlin:mvikotlin:$VERSION"
             const val mvikotlinMain = "com.arkivanov.mvikotlin:mvikotlin-main:$VERSION"
-            const val mvikotlinMainIosX64 = "com.arkivanov.mvikotlin:mvikotlin-main-iosx64:$VERSION"
-            const val mvikotlinMainIosArm64 = "com.arkivanov.mvikotlin:mvikotlin-main-iosarm64:$VERSION"
             const val mvikotlinLogging = "com.arkivanov.mvikotlin:mvikotlin-logging:$VERSION"
             const val mvikotlinTimeTravel = "com.arkivanov.mvikotlin:mvikotlin-timetravel:$VERSION"
             const val mvikotlinExtensionsReaktive = "com.arkivanov.mvikotlin:mvikotlin-extensions-reaktive:$VERSION"
@@ -51,8 +49,6 @@ object Deps {
         object Decompose {
             private const val VERSION = "0.2.3"
             const val decompose = "com.arkivanov.decompose:decompose:$VERSION"
-            const val decomposeIosX64 = "com.arkivanov.decompose:decompose-iosx64:$VERSION"
-            const val decomposeIosArm64 = "com.arkivanov.decompose:decompose-iosarm64:$VERSION"
             const val extensionsCompose = "com.arkivanov.decompose:extensions-compose-jetbrains:$VERSION"
         }
     }

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -15,20 +15,8 @@ kotlin {
                 export(project(":common:database"))
                 export(project(":common:main"))
                 export(project(":common:edit"))
-
-                when (val target = this.compilation.target.name) {
-                    "iosX64" -> {
-                        export(Deps.ArkIvanov.Decompose.decomposeIosX64)
-                        export(Deps.ArkIvanov.MVIKotlin.mvikotlinMainIosX64)
-                    }
-
-                    "iosArm64" -> {
-                        export(Deps.ArkIvanov.Decompose.decomposeIosArm64)
-                        export(Deps.ArkIvanov.MVIKotlin.mvikotlinMainIosArm64)
-                    }
-
-                    else -> error("Unsupported target: $target")
-                }
+                export(Deps.ArkIvanov.Decompose.decompose)
+                export(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
             }
         }
     }
@@ -53,20 +41,8 @@ kotlin {
                 api(project(":common:database"))
                 api(project(":common:main"))
                 api(project(":common:edit"))
-            }
-        }
-
-        named("iosX64Main") {
-            dependencies {
-                api(Deps.ArkIvanov.Decompose.decomposeIosX64)
-                api(Deps.ArkIvanov.MVIKotlin.mvikotlinMainIosX64)
-            }
-        }
-
-        named("iosArm64Main") {
-            dependencies {
-                api(Deps.ArkIvanov.Decompose.decomposeIosArm64)
-                api(Deps.ArkIvanov.MVIKotlin.mvikotlinMainIosArm64)
+                api(Deps.ArkIvanov.Decompose.decompose)
+                api(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
             }
         }
     }


### PR DESCRIPTION
It seems that we can now use "common" artifacts for iOS framework export. Don't remember what was the original issue. Checked the iOS app, it compiles and runs fine.