### PR TITLE
[compose-web-example] Fix package issues and code cleanup

### DIFF
--- a/examples/falling_balls_with_web/build.gradle.kts
+++ b/examples/falling_balls_with_web/build.gradle.kts
@@ -30,9 +30,9 @@ kotlin {
         }
 
         val jvmMain by getting {
-             dependencies {
+            dependencies {
                 implementation(compose.desktop.currentOs)
-             }
+            }
         }
 
 
@@ -47,13 +47,13 @@ kotlin {
 
 compose.desktop {
     application {
-        mainClass = "org.jetbrains.compose.common.demo.AppKt"
+        mainClass = "AppKt"
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "ImageViewer"
             packageVersion = "1.0.0"
-            
+
             modules("jdk.crypto.ec")
 
             val iconsRoot = project.file("../common/src/desktopMain/resources/images")

--- a/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/Game.kt
+++ b/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/Game.kt
@@ -1,11 +1,11 @@
-package org.jetbrains.compose.demo.falling
+package fallingBalls
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import org.jetbrains.compose.common.ui.unit.IntSize
 import org.jetbrains.compose.common.core.graphics.Color
+import org.jetbrains.compose.common.ui.unit.IntSize
 import kotlin.random.Random
 
 private fun Color.Companion.random() =

--- a/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/Piece.kt
+++ b/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/Piece.kt
@@ -1,19 +1,17 @@
-package org.jetbrains.compose.demo.falling.views
+package fallingBalls
 
 import androidx.compose.runtime.Composable
-import org.jetbrains.compose.demo.falling.PieceData
-import org.jetbrains.compose.common.ui.Modifier
-import org.jetbrains.compose.common.foundation.layout.Box
-import org.jetbrains.compose.common.ui.unit.dp
-import org.jetbrains.compose.common.ui.unit.Dp
-import org.jetbrains.compose.common.foundation.layout.offset
-import org.jetbrains.compose.common.ui.background
-import org.jetbrains.compose.common.ui.size
-import org.jetbrains.compose.common.foundation.clickable
-import org.jetbrains.compose.common.ui.draw.clip
-import org.jetbrains.compose.common.core.graphics.Color
 import jetbrains.compose.common.shapes.CircleShape
-import org.jetbrains.compose.common.demo.position
+import modifiers.position
+import org.jetbrains.compose.common.core.graphics.Color
+import org.jetbrains.compose.common.foundation.clickable
+import org.jetbrains.compose.common.foundation.layout.Box
+import org.jetbrains.compose.common.ui.Modifier
+import org.jetbrains.compose.common.ui.background
+import org.jetbrains.compose.common.ui.draw.clip
+import org.jetbrains.compose.common.ui.size
+import org.jetbrains.compose.common.ui.unit.Dp
+import org.jetbrains.compose.common.ui.unit.dp
 
 @Composable
 fun Piece(index: Int, piece: PieceData) {

--- a/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/PieceData.kt
+++ b/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/PieceData.kt
@@ -1,8 +1,8 @@
-package org.jetbrains.compose.demo.falling
+package fallingBalls
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.getValue
 import org.jetbrains.compose.common.core.graphics.Color
 
 data class PieceData(val game: Game, val velocity: Float, val color: Color) {

--- a/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/fallingBalls.kt
+++ b/examples/falling_balls_with_web/src/commonMain/kotlin/fallingBalls/fallingBalls.kt
@@ -1,34 +1,27 @@
-package org.jetbrains.compose.demo.falling.views
+package fallingBalls
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.withFrameNanos
-import org.jetbrains.compose.demo.falling.Game
-import org.jetbrains.compose.common.material.Text
-import org.jetbrains.compose.common.foundation.layout.Column
-import org.jetbrains.compose.common.material.Slider
-import org.jetbrains.compose.common.foundation.layout.Row
-import org.jetbrains.compose.common.foundation.layout.Box
-import org.jetbrains.compose.common.material.Button
-import org.jetbrains.compose.common.ui.Modifier
-import org.jetbrains.compose.common.ui.unit.em
-import org.jetbrains.compose.common.ui.unit.dp
-import org.jetbrains.compose.common.foundation.layout.offset
-import org.jetbrains.compose.common.foundation.layout.width
-import org.jetbrains.compose.common.ui.layout.onSizeChanged
-import org.jetbrains.compose.common.ui.background
-import org.jetbrains.compose.common.foundation.border
-import org.jetbrains.compose.common.ui.size
 import org.jetbrains.compose.common.core.graphics.Color
-import org.jetbrains.compose.common.foundation.layout.fillMaxHeight
-import org.jetbrains.compose.common.foundation.layout.fillMaxWidth
+import org.jetbrains.compose.common.foundation.border
+import org.jetbrains.compose.common.foundation.layout.*
+import org.jetbrains.compose.common.material.Button
+import org.jetbrains.compose.common.material.Slider
+import org.jetbrains.compose.common.material.Text
+import org.jetbrains.compose.common.ui.Modifier
+import org.jetbrains.compose.common.ui.background
+import org.jetbrains.compose.common.ui.layout.onSizeChanged
+import org.jetbrains.compose.common.ui.size
+import org.jetbrains.compose.common.ui.unit.dp
+import org.jetbrains.compose.common.ui.unit.em
 
 @Composable
 fun fallingBalls(game: Game) {
     Column(Modifier.fillMaxWidth().fillMaxHeight(1f)) {
         Box() {
             Text(
-                "Catch balls!${if (game.finished) " Game over!" else ""}",
+                "Catch balls!${if (game.finished) " fallingBalls.Game over!" else ""}",
                 size = 1.8f.em,
                 color = Color(218, 120, 91)
             )

--- a/examples/falling_balls_with_web/src/commonMain/kotlin/modifiers/position.kt
+++ b/examples/falling_balls_with_web/src/commonMain/kotlin/modifiers/position.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.compose.common.demo
+package modifiers
 
 import androidx.compose.runtime.Composable
 import org.jetbrains.compose.common.ui.Modifier

--- a/examples/falling_balls_with_web/src/jsMain/kotlin/App.kt
+++ b/examples/falling_balls_with_web/src/jsMain/kotlin/App.kt
@@ -1,14 +1,12 @@
-package org.jetbrainsc.compose.common.demo
-
-import androidx.compose.web.renderComposable
-import kotlinx.browser.document
-import org.w3c.dom.HTMLElement
-import org.jetbrains.compose.demo.falling.views.fallingBalls
-import org.jetbrains.compose.demo.falling.Game
 import androidx.compose.runtime.remember
-import kotlinx.browser.window
 import androidx.compose.web.css.Style
+import androidx.compose.web.renderComposable
+import fallingBalls.Game
+import fallingBalls.fallingBalls
+import kotlinx.browser.document
+import kotlinx.browser.window
 import org.jetbrains.compose.web.ui.Styles
+import org.w3c.dom.HTMLElement
 
 class JsGame : Game() {
     override fun now() = window.performance.now().toLong()
@@ -21,8 +19,8 @@ fun main() {
         Style(Styles)
         val game = remember {
             JsGame().apply {
-              width = root.offsetWidth
-              height = root.offsetHeight
+                width = root.offsetWidth
+                height = root.offsetHeight
             }
         }
         fallingBalls(game)

--- a/examples/falling_balls_with_web/src/jsMain/kotlin/modifiers/position.kt
+++ b/examples/falling_balls_with_web/src/jsMain/kotlin/modifiers/position.kt
@@ -1,18 +1,13 @@
-package org.jetbrains.compose.common.demo
+package modifiers
 
 import androidx.compose.runtime.Composable
-import org.jetbrains.compose.common.ui.Modifier
-import org.jetbrains.compose.common.foundation.layout.offset
-import org.jetbrains.compose.common.ui.unit.Dp
+import androidx.compose.web.css.*
 import org.jetbrains.compose.common.internal.castOrCreate
-import androidx.compose.web.css.top
-import androidx.compose.web.css.left
-import androidx.compose.web.css.px
-import androidx.compose.web.css.position
-import androidx.compose.web.css.Position
+import org.jetbrains.compose.common.ui.Modifier
+import org.jetbrains.compose.common.ui.unit.Dp
 
 @Composable
-actual fun Modifier.position(width: Dp, height: Dp): Modifier  = castOrCreate().apply {
+actual fun Modifier.position(width: Dp, height: Dp): Modifier = castOrCreate().apply {
     add {
         position(Position.Absolute)
         top(height.value.px)

--- a/examples/falling_balls_with_web/src/jsMain/resources/index.html
+++ b/examples/falling_balls_with_web/src/jsMain/resources/index.html
@@ -19,11 +19,11 @@
 <head>
     <meta charset="UTF-8">
     <title>compose-browser-with-web-demo</title>
-    <link type="text/css" rel="stylesheet" href="styles.css" />
+    <link href="styles.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>
-    <div id="root"></div>
-    <script src="falling_balls_with_web.js">
-    </script>
+<div id="root"></div>
+<script src="falling_balls_with_web.js">
+</script>
 </body>
 </html>

--- a/examples/falling_balls_with_web/src/jvmMain/kotlin/App.kt
+++ b/examples/falling_balls_with_web/src/jvmMain/kotlin/App.kt
@@ -1,10 +1,8 @@
-package org.jetbrains.compose.common.demo
-
 import androidx.compose.desktop.Window
-import androidx.compose.ui.unit.IntSize
-import org.jetbrains.compose.demo.falling.views.fallingBalls
-import org.jetbrains.compose.demo.falling.Game
 import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.IntSize
+import fallingBalls.Game
+import fallingBalls.fallingBalls
 
 class JvmGame : Game() {
     override fun now() = System.nanoTime()

--- a/examples/falling_balls_with_web/src/jvmMain/kotlin/modifiers/position.kt
+++ b/examples/falling_balls_with_web/src/jvmMain/kotlin/modifiers/position.kt
@@ -1,12 +1,11 @@
-package org.jetbrains.compose.common.demo
+package modifiers
 
-import androidx.compose.runtime.Composable
-import org.jetbrains.compose.common.ui.Modifier
-import org.jetbrains.compose.common.foundation.layout.offset
-import org.jetbrains.compose.common.ui.unit.Dp
-import org.jetbrains.compose.common.internal.castOrCreate
-import org.jetbrains.compose.common.ui.unit.implementation
 import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.common.internal.castOrCreate
+import org.jetbrains.compose.common.ui.Modifier
+import org.jetbrains.compose.common.ui.unit.Dp
+import org.jetbrains.compose.common.ui.unit.implementation
 
 @Composable
 actual fun Modifier.position(width: Dp, height: Dp): Modifier = castOrCreate().apply {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9678279/119989973-6b16bb80-bfe5-11eb-807e-0e88b8833184.png)


Currently, `compose-web`'s `falling_balls_with_web` example has misaligned package names which show as a warning in the IDE. 
This PR will fix those issues and also does a code cleanup.

