### PR TITLE
Web: Fix Option usage in Select Element

### DIFF
--- a/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
@@ -249,7 +249,7 @@ fun Select(
 )
 
 @Composable
-fun DOMScope<HTMLUListElement>.Option(
+fun DOMScope<HTMLSelectElement>.Option(
     value: String,
     attrs: AttrBuilderContext<Tag.Option> = {},
     content: ContentBuilder<HTMLOptionElement>? = null

--- a/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
@@ -249,7 +249,7 @@ fun Select(
 )
 
 @Composable
-fun DOMScope<HTMLSelectElement>.Option(
+fun Option(
     value: String,
     attrs: AttrBuilderContext<Tag.Option> = {},
     content: ContentBuilder<HTMLOptionElement>? = null


### PR DESCRIPTION
Currently not possible: 
```kotlin
Select {
  Option(value = "foo") {
    Text("Foo")
  }
}
```