### PR TITLE
Web: Remove content builder for empty elements

### DIFF
--- a/web/benchmark-core/src/jsMain/kotlin/com/sample/content/Header.kt
+++ b/web/benchmark-core/src/jsMain/kotlin/com/sample/content/Header.kt
@@ -62,7 +62,7 @@ private fun LanguageButton() {
                     property("padding-left", value(8.px))
                     property("padding-right", value(8.px))
                 }
-            }) {}
+            })
             Text("English")
         }
     }

--- a/web/benchmark-core/src/jsMain/kotlin/com/sample/content/IntroSection.kt
+++ b/web/benchmark-core/src/jsMain/kotlin/com/sample/content/IntroSection.kt
@@ -21,7 +21,7 @@ fun Intro() {
                 classes(WtCols.wtCol2, WtCols.wtColMd3)
                 styleBuilder.alignSelf(AlignSelf.Start)
             }) {
-                Img(src = "i1.svg", attrs = { classes(AppStylesheet.composeLogo) }) {}
+                Img(src = "i1.svg", attrs = { classes(AppStylesheet.composeLogo) })
             }
 
             Div(attrs = {
@@ -202,7 +202,7 @@ private fun ComposeWebStatusMessage() {
                     width(24.px)
                     height(24.px)
                 }
-            }) {}
+            })
         }
 
         Div(attrs = {

--- a/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/elements/Elements.kt
@@ -88,8 +88,7 @@ fun A(
 fun Input(
     type: InputType = InputType.Text,
     value: String = "",
-    attrs: AttrBuilderContext<Tag.Input> = {},
-    content: ContentBuilder<HTMLInputElement>? = null
+    attrs: AttrBuilderContext<Tag.Input> = {}
 ) {
     TagElement<Tag.Input, HTMLInputElement>(
         tagName = "input",
@@ -98,7 +97,7 @@ fun Input(
             value(value)
             attrs()
         },
-        content = content
+        content = null
     )
 }
 
@@ -181,10 +180,8 @@ fun Span(
 ) = TagElement("span", applyAttrs = attrs, content = content)
 
 @Composable
-fun Br(
-    attrs: AttrBuilderContext<Tag.Br> = {},
-    content: ContentBuilder<HTMLBRElement>? = null
-) = TagElement("br", applyAttrs = attrs, content = content)
+fun Br(attrs: AttrBuilderContext<Tag.Br> = {}) =
+    TagElement<Tag.Br, HTMLBRElement>("br", applyAttrs = attrs, content = null)
 
 @Composable
 fun Ul(
@@ -214,15 +211,14 @@ fun DOMScope<HTMLUListElement>.Li(
 fun Img(
     src: String,
     alt: String = "",
-    attrs: AttrBuilderContext<Tag.Img> = {},
-    content: ContentBuilder<HTMLImageElement>? = null
+    attrs: AttrBuilderContext<Tag.Img> = {}
 ) = TagElement<Tag.Img, HTMLImageElement>(
     tagName = "img",
     applyAttrs = {
         src(src).alt(alt)
         attrs()
     },
-    content = content
+    content = null
 )
 
 @Composable
@@ -412,13 +408,12 @@ fun Caption(
 
 @Composable
 fun Col(
-    attrs: AttrBuilderContext<Tag.Col> = {},
-    content: ContentBuilder<HTMLTableColElement>? = null
+    attrs: AttrBuilderContext<Tag.Col> = {}
 ) {
-    TagElement(
+    TagElement<Tag.Col, HTMLTableColElement>(
         tagName = "col",
         applyAttrs = attrs,
-        content = content
+        content = null
     )
 }
 

--- a/web/core/src/jsTest/kotlin/elements/TableTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/TableTests.kt
@@ -25,11 +25,9 @@ class TableTests {
     @Test
     fun colAttributes() = runTest {
         composition {
-            Col(
-                {
-                    span(2)
-                }
-            ) { }
+            Col {
+                span(2)
+            }
         }
 
         assertEquals(
@@ -46,9 +44,9 @@ class TableTests {
                     Text("CaptionText")
                 }
                 Colgroup {
-                    Col { }
-                    Col { }
-                    Col { }
+                    Col()
+                    Col()
+                    Col()
                 }
                 Thead {
                     Tr {

--- a/web/widgets/src/jsMain/kotlin/layouts/slider.kt
+++ b/web/widgets/src/jsMain/kotlin/layouts/slider.kt
@@ -28,5 +28,5 @@ actual fun SliderActual(
                 onValueChange(value.toFloat())
             }
         }
-    ) {}
+    )
 }


### PR DESCRIPTION
Fix #744

Reference: https://developer.mozilla.org/en-US/docs/Glossary/Empty_element