### PR TITLE
[codeviewer] Fix invalid Char code exception for readLinePositions

### DIFF
--- a/examples/codeviewer/common/src/jvmMain/kotlin/org/jetbrains/codeviewer/platform/JvmFile.kt
+++ b/examples/codeviewer/common/src/jvmMain/kotlin/org/jetbrains/codeviewer/platform/JvmFile.kt
@@ -94,7 +94,7 @@ private fun java.io.File.readLinePositions(
                 if (isBeginOfLine) {
                     starts.add(position.toInt())
                 }
-                isBeginOfLine = Char(byte.toInt()) == '\n'
+                isBeginOfLine = byte.toInt().toChar() == '\n'
                 position++
             }
             channel.close()


### PR DESCRIPTION
Open a file by the _codeviewer_, there will be a crash, the stack is as follows:

```kotlin
Exception in thread "DefaultDispatcher-worker-1 @coroutine#345" java.lang.IllegalArgumentException: Invalid Char code: -27
	at org.jetbrains.codeviewer.platform.JvmFileKt.readLinePositions(JvmFile.kt:97)
	at org.jetbrains.codeviewer.platform.JvmFileKt.access$readLinePositions(JvmFile.kt:1)
	at org.jetbrains.codeviewer.platform.JvmFileKt$toProjectFile$1$readLines$1.invokeSuspend(JvmFile.kt:52)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

The related code line:

```kotlin
isBeginOfLine = Char(byte.toInt()) == '\n'
```

And the source of the `Char(Int)`:

```kotlin
/**
 * Creates a Char with the specified [code], or throws an exception if the [code] is out of `Char.MIN_VALUE.code..Char.MAX_VALUE.code`.
 *
 * If the program that calls this function is written in a way that only valid [code] is passed as the argument,
 * using the overload that takes a [UShort] argument is preferable (`Char(intValue.toUShort())`).
 * That overload doesn't check validity of the argument, and may improve program performance when the function is called routinely inside a loop.
 *
 * @sample samples.text.Chars.charFromCode
 */
@SinceKotlin("1.5")
@WasExperimental(ExperimentalStdlibApi::class)
@kotlin.internal.InlineOnly
public inline fun Char(code: Int): Char {
    if (code < Char.MIN_VALUE.code || code > Char.MAX_VALUE.code) {
        throw IllegalArgumentException("Invalid Char code: $code") // <---
    }
    return Char(code.toUShort())
}
```

Obviously, we should not use this `Char` constructor(actually it is a `fun`) here. 

The solution is very simple, change to `toChar()` to avoid this exception.

