### PR TITLE
Fix `add1kItems` benchmark to avoid it getting swallowed on CI

### DIFF
--- a/web/benchmark-core/src/jsTest/kotlin/BenchmarkTests.kt
+++ b/web/benchmark-core/src/jsTest/kotlin/BenchmarkTests.kt
@@ -65,8 +65,8 @@ class BenchmarkTests {
         return duration
     }
 
-    @Test
-    fun add1kItems() = runBenchmark("add1000Items") {
+    @Test // add1kItems overrides default `repeat` value (was - 5, now - 3) to avoid getting swallowed on CI
+    fun add1kItems() = runBenchmark(name = "add1000Items", repeat = 3) {
         addNItems(1000)
     }
 


### PR DESCRIPTION
Now it will repeat only 3 times instead of default (5).