### PR TITLE
Remove the boolean parameter from hidden() to align with #780

### DIFF
--- a/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/AttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/AttrsBuilder.kt
@@ -21,7 +21,7 @@ class AttrsBuilder<TElement : Element> : EventsListenerBuilder() {
     fun classes(vararg classes: String) = prop(setClassList, classes)
 
     fun id(value: String) = attr(ID, value)
-    fun hidden(value: Boolean) = attr(HIDDEN, value.toString())
+    fun hidden() = attr(HIDDEN, true.toString())
     fun title(value: String) = attr(TITLE, value)
     fun dir(value: DirType) = attr(DIR, value.dirStr)
     fun draggable(value: Draggable) = attr(DRAGGABLE, value.str)


### PR DESCRIPTION
In #780, all attributes builder functions with a boolean parameter were removed, like `disabled(true)` => `disabled()`. 
This one was left. 

@Schahen 