### PR TITLE
Automatically add `-Dcompose.application.configure.swing.globals=true to run/package tasks

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -24,6 +24,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import java.io.File
 import java.util.*
 
+private val defaultJvmArgs = listOf("-Dcompose.application.configure.swing.globals=true")
+
 // todo: multiple launchers
 // todo: file associations
 // todo: use workers
@@ -205,7 +207,7 @@ internal fun AbstractJPackageTask.configurePackagingTask(
     }
 
     launcherMainClass.set(provider { app.mainClass })
-    launcherJvmArgs.set(provider { app.jvmArgs })
+    launcherJvmArgs.set(provider { defaultJvmArgs + app.jvmArgs })
     launcherArgs.set(provider { app.args })
 }
 
@@ -284,7 +286,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
 private fun JavaExec.configureRunTask(app: Application) {
     mainClass.set(provider { app.mainClass })
     executable(javaExecutable(app.javaHomeOrDefault()))
-    jvmArgs = app.jvmArgs
+    jvmArgs = defaultJvmArgs + app.jvmArgs
     args = app.args
 
     val cp = project.objects.fileCollection()

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/gradle/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/gradle/DesktopApplicationTest.kt
@@ -244,6 +244,44 @@ class DesktopApplicationTest : GradlePluginTestBase() {
     }
 
     @Test
+    fun testDefaultArgs() {
+        with(testProject(TestProjects.defaultArgs)) {
+            fun testRunTask(runTask: String) {
+                gradle(runTask).build().checks { check ->
+                    check.taskOutcome(runTask, TaskOutcome.SUCCESS)
+                    check.logContains("compose.application.configure.swing.globals=true")
+                }
+            }
+
+            testRunTask(":runDistributable")
+            testRunTask(":run")
+
+            gradle(":package").build().checks { check ->
+                check.taskOutcome(":package", TaskOutcome.SUCCESS)
+            }
+        }
+    }
+
+    @Test
+    fun testDefaultArgsOverride() {
+        with(testProject(TestProjects.defaultArgsOverride)) {
+            fun testRunTask(runTask: String) {
+                gradle(runTask).build().checks { check ->
+                    check.taskOutcome(runTask, TaskOutcome.SUCCESS)
+                    check.logContains("compose.application.configure.swing.globals=false")
+                }
+            }
+
+            testRunTask(":runDistributable")
+            testRunTask(":run")
+
+            gradle(":package").build().checks { check ->
+                check.taskOutcome(":package", TaskOutcome.SUCCESS)
+            }
+        }
+    }
+
+    @Test
     fun testSuggestModules() {
         with(testProject(TestProjects.jvm)) {
             gradle(":suggestRuntimeModules").build().checks { check ->

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProjects.kt
@@ -14,6 +14,8 @@ object TestProjects {
     const val macOptions = "application/macOptions"
     const val macSign = "application/macSign"
     const val optionsWithSpaces = "application/optionsWithSpaces"
+    const val defaultArgs = "application/defaultArgs"
+    const val defaultArgsOverride = "application/defaultArgsOverride"
     const val unpackSkiko = "application/unpackSkiko"
     const val jsMpp = "misc/jsMpp"
 }

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/build.gradle
@@ -1,0 +1,30 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.compose"
+}
+
+repositories {
+    google()
+    mavenCentral()
+    maven {
+        url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation compose.desktop.currentOs
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageVersion = "1.0.0"
+            packageName = "Test Package"
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.compose' version 'COMPOSE_VERSION_PLACEHOLDER'
+    }
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/src/main/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgs/src/main/kotlin/main.kt
@@ -1,0 +1,3 @@
+fun main(args: Array<String>) {
+    println("compose.application.configure.swing.globals=${java.lang.System.getProperty("compose.application.configure.swing.globals")}")
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/build.gradle
@@ -1,0 +1,32 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    id "org.jetbrains.kotlin.jvm"
+    id "org.jetbrains.compose"
+}
+
+repositories {
+    google()
+    mavenCentral()
+    maven {
+        url "https://maven.pkg.jetbrains.space/public/p/compose/dev"
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation compose.desktop.currentOs
+}
+
+compose.desktop {
+    application {
+        mainClass = "MainKt"
+        nativeDistributions {
+            targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+            packageVersion = "1.0.0"
+            packageName = "Test Package"
+
+            jvmArgs("-Dcompose.application.configure.swing.globals=false")
+        }
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version 'KOTLIN_VERSION_PLACEHOLDER'
+        id 'org.jetbrains.compose' version 'COMPOSE_VERSION_PLACEHOLDER'
+    }
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}

--- a/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/src/main/kotlin/main.kt
+++ b/gradle-plugins/compose/src/test/test-projects/application/defaultArgsOverride/src/main/kotlin/main.kt
@@ -1,0 +1,3 @@
+fun main(args: Array<String>) {
+    println("compose.application.configure.swing.globals=${java.lang.System.getProperty("compose.application.configure.swing.globals")}")
+}


### PR DESCRIPTION
When users run/package application we will configure Compose to work as standalone application.

It means we will override some global Swing properties in Compose initialization function:
- sets system property `apple.laf.useScreenMenuBar` to true
- sets system property `sun.java2d.uiScale`/`sun.java2d.uiScale.enabled` automatically on Linux
- sets `UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())`

When users don't use those tasks (when they use Compose in an existing Swing application, or in an IDEA plugin),
this property will not be set, and so we will not override Swing globals.

If users don't want to override Swing's globals, they can change the default behavior in build.gradle:
`jvmArgs("-Dcompose.application.configure.swing.globals=false")`

See [androidx CL](https://android-review.googlesource.com/c/platform/frameworks/support/+/1748236)