### PR TITLE
Update tutorials check task to support individual targets checks

### DIFF
--- a/tutorials/checker/gradle.properties
+++ b/tutorials/checker/gradle.properties
@@ -1,1 +1,5 @@
 kotlin.code.style=official
+
+# Helps running check only for specified target (or all of them)
+# Available values (case insensitive): web, desktop, all
+CHECK_TARGET=ALL


### PR DESCRIPTION
This change will help investigate and fix inconsistencies in the tutorials a little faster since it's easier to run individual checks (for web/desktop or all)

`./gradlew check -PCHECK_TARGET=all` - `all` is the default, so can be omitted
`./gradlew check -PCHECK_TARGET=desktop`
`./gradlew check -PCHECK_TARGET=web`

This PR also changes the command used for web tutorials: `build` -> `compileKotlinJs` (it should be enough). It saves ~1 minute when running the check for all targets.