### PR TITLE
Use Gradle 7.1 for building Gradle and Intellij plugin

### DIFF
--- a/gradle-plugins/build.gradle.kts
+++ b/gradle-plugins/build.gradle.kts
@@ -3,8 +3,7 @@ import com.gradle.publish.PluginBundleExtension
 plugins {
     // __KOTLIN_COMPOSE_VERSION__
     kotlin("jvm") version "1.5.10" apply false
-    id("com.gradle.plugin-publish") version "0.10.1" apply false
-    id("de.fuerstenau.buildconfig") version "1.1.8" apply false
+    id("com.gradle.plugin-publish") version "0.15.0" apply false
 }
 
 subprojects {

--- a/gradle-plugins/buildSrc/src/main/kotlin/GenerateBuildConfig.kt
+++ b/gradle-plugins/buildSrc/src/main/kotlin/GenerateBuildConfig.kt
@@ -1,0 +1,51 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.mapProperty
+import org.gradle.kotlin.dsl.property
+
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+open class GenerateBuildConfig : DefaultTask() {
+    @get:Input
+    val fieldsToGenerate: MapProperty<String, Any> = project.objects.mapProperty()
+
+    @get:Input
+    val classFqName: Property<String> = project.objects.property()
+
+    @get:OutputDirectory
+    val generatedOutputDir: DirectoryProperty = project.objects.directoryProperty()
+
+    @TaskAction
+    fun execute() {
+        val dir = generatedOutputDir.get().asFile
+        dir.deleteRecursively()
+        dir.mkdirs()
+
+        val fqName = classFqName.get()
+        val parts = fqName.split(".")
+        val className = parts.last()
+        val file = dir.resolve("$className.kt")
+        val content = buildString {
+            if (parts.size > 1) {
+                appendLine("package ${parts.dropLast(1).joinToString(".")}")
+            }
+
+            appendLine()
+            appendLine("/* GENERATED, DO NOT EDIT MANUALLY! */")
+            appendLine("object $className {")
+            for ((k, v) in fieldsToGenerate.get().entries.sortedBy { it.key }) {
+                appendLine("const val $k = ${if (v is String) "\"$v\"" else v.toString()}")
+            }
+            appendLine("}")
+        }
+        file.writeText(content)
+    }
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/preview/tasks/AbstractConfigureDesktopPreviewTask.kt
@@ -37,7 +37,7 @@ abstract class AbstractConfigureDesktopPreviewTask : AbstractComposeDesktopTask(
 
     @get:InputFiles
     internal val hostClasspath = project.configurations.detachedConfiguration(
-        project.dependencies.create("org.jetbrains.compose:preview-rpc:${ComposeBuildConfig.VERSION}")
+        project.dependencies.create("org.jetbrains.compose:preview-rpc:${ComposeBuildConfig.composeVersion}")
     )
 
     @TaskAction

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/gradle/GradlePluginTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/gradle/GradlePluginTest.kt
@@ -18,7 +18,7 @@ class GradlePluginTest : GradlePluginTestBase() {
         with(
             testProject(
                 TestProjects.jsMpp,
-                testEnvironment = defaultTestEnvironment.copy(kotlinVersion = TestKotlinVersion.V1_5_20_dev_3226)
+                testEnvironment = defaultTestEnvironment.copy(kotlinVersion = TestKotlinVersion.V1_5_20)
             )
         ) {
             gradle(":compileKotlinJs").build().checks { check ->

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestKotlinVersion.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestKotlinVersion.kt
@@ -9,5 +9,5 @@ package org.jetbrains.compose.test
 enum class TestKotlinVersion(val versionString: String) {
     // __KOTLIN_COMPOSE_VERSION__
     Default("1.5.10"),
-    V1_5_20_dev_3226("1.5.20-dev-3226")
+    V1_5_20("1.5.20")
 }

--- a/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/idea-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/idea-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Replace usage of 'de.fuerstenau.buildconfig'
with a custom replacement, because the plugin
does not support Gradle 7.0+ and
there has not been any commit activity in 5 years
(https://github.com/mfuerstenau/gradle-buildconfig-plugin);
* Update 'com.github.johnrengelman.shadow' to 7.0.0