### PR TITLE
Add a workaround for compose js targets to use compose with kotlinx.serialization

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerKotlinSupportPlugin.kt
@@ -39,6 +39,10 @@ class ComposeCompilerKotlinSupportPlugin : KotlinCompilerPluginSupportPlugin {
         if (kotlinTarget !is KotlinJsIrTarget) return false
 
         val project = kotlinTarget.project
+        if (project.shouldFixKotlinxSerializationAndComposeOrderForJsTarget()) {
+            return false
+        }
+
         val webExt = project.webExt ?: return false
 
         return kotlinTarget in webExt.targetsToConfigure(project)


### PR DESCRIPTION
Add a workaround for compose js targets to use compose with kotlinx.serialization

The workaround is to force the order of the plugins: compose compiler plugin will be executed in the end.

To enable the workaround `FIX_KOTLINX_SERIALIZATION_COMPOSE_ORDER_IN_JS` needs to be set in gradle.properties:
FIX_KOTLINX_SERIALIZATION_COMPOSE_ORDER_IN_JS=true