### PR TITLE
web: Add Event Listener Options

### DIFF
--- a/web/core/src/jsMain/kotlin/androidx/compose/web/DomApplier.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/DomApplier.kt
@@ -52,13 +52,29 @@ open class DomNodeWrapper(open val node: Node) {
         val htmlElement = node as? HTMLElement ?: return
 
         currentListeners.forEach {
-            htmlElement.removeEventListener(it.event, it)
+            htmlElement.removeEventListener(it.event, it, it.options.toJsObject())
         }
 
         currentListeners = list
 
         currentListeners.forEach {
-            htmlElement.addEventListener(it.event, it)
+            htmlElement.addEventListener(it.event, it, it.options.toJsObject())
+        }
+    }
+
+    private fun Options.BooleanValue.toBoolean(): Boolean? = when (this) {
+        Options.BooleanValue.True -> true
+        Options.BooleanValue.False -> false
+        Options.BooleanValue.Default -> null
+    }
+
+    // This conversion helps to preserve the default values of options parameters (defaults can vary per browser)
+    private fun Options.toJsObject(): EventListenerOptions {
+        val options = this
+        return jsObject {
+            if (options.once != Options.BooleanValue.Default) once = options.once.toBoolean()!!
+            if (options.passive != Options.BooleanValue.Default) passive = options.passive.toBoolean()!!
+            if (options.capture != Options.BooleanValue.Default) capture = options.capture.toBoolean()!!
         }
     }
 

--- a/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/WrappedEventListener.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/WrappedEventListener.kt
@@ -37,11 +37,26 @@ open class WrappedEventListener<T : GenericWrappedEvent<*>>(
     }
 }
 
-class Options {
-    // TODO: add options for addEventListener
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#parameters
+ *
+ * Parameter `signal` of type [AbortSignal](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) is not added here.
+ * The reason is that its usage is most often not compliant with Compose concepts.
+ *
+ * TODO: Parameter `once` is also not compliant with Compose concepts (similar to `signal`). Consider its necessity.
+ */
+class Options(
+    val capture: BooleanValue = BooleanValue.Default,
+    val once: BooleanValue = BooleanValue.Default,
+    val passive: BooleanValue = BooleanValue.Default,
+) {
 
     companion object {
         val DEFAULT = Options()
+    }
+
+    enum class BooleanValue {
+        True, False, Default;
     }
 }
 

--- a/web/core/src/jsTest/kotlin/elements/EventTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/EventTests.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.compose.web.core.tests
 
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.currentRecomposeScope
 import org.jetbrains.compose.web.attributes.InputType
-import org.jetbrains.compose.web.dom.Button
-import org.jetbrains.compose.web.dom.Input
-import org.jetbrains.compose.web.dom.TextArea
+import org.jetbrains.compose.web.attributes.Options
+import org.jetbrains.compose.web.dom.*
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.HTMLParagraphElement
 import org.w3c.dom.HTMLTextAreaElement
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.InputEvent
@@ -34,6 +36,195 @@ class EventTests {
         btn.dispatchEvent(MouseEvent("click"))
 
         assertTrue(handled)
+    }
+
+    @Test
+    fun multipleEventListenersCanBeAddedAndUsed() = runTest {
+        var handled1 = false
+        var handled2 = false
+
+        composition {
+            Button(
+                {
+                    onClick { handled1 = true }
+                    onClick { handled2 = true }
+                }
+            ) {}
+        }
+
+        assertEquals(1, root.childElementCount)
+
+        val btn = root.firstChild as HTMLElement
+        btn.dispatchEvent(MouseEvent("click"))
+
+        assertTrue(handled1)
+        assertTrue(handled2)
+    }
+
+    @Test
+    fun multipleButtonClickHandled() = runTest {
+        var count = 0
+
+        composition {
+            Button(attrs = { onClick { count++ } })
+        }
+
+        assertEquals(1, root.childElementCount)
+
+        val btn = root.firstChild as HTMLElement
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+
+        assertEquals(3, count)
+    }
+
+    @Test
+    fun buttonOnClickHandlerWithOnceOptionCalledOnlyOnce() = runTest {
+        var count = 0
+
+        composition {
+            Button(attrs = { onClick(options = Options(once = Options.BooleanValue.True)) { count++ } })
+        }
+
+        assertEquals(1, root.childElementCount)
+
+        val btn = root.firstChild as HTMLElement
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun buttonOnClickHandlerWithOnceOptionCalledAgainAfterRecomposition() = runTest {
+        var count = 0
+        var composedTimes = 0
+
+        var recomposeScope: RecomposeScope? = null
+
+        composition {
+            recomposeScope = currentRecomposeScope
+            composedTimes++
+
+            Button(attrs = { onClick(options = Options(once = Options.BooleanValue.True)) { count++ } })
+        }
+
+        assertEquals(1, composedTimes)
+
+        assertEquals(1, root.childElementCount)
+
+        val btn = root.firstChild as HTMLElement
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+
+        assertEquals(1, count)
+
+        recomposeScope!!.invalidate()
+        waitForAnimationFrame()
+
+        assertEquals(2, composedTimes)
+
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+        btn.dispatchEvent(MouseEvent("click"))
+
+        assertEquals(2, count)
+
+    }
+
+    @Test
+    fun removedEventListenersGetNeverCalled() = runTest {
+        var count = 0
+        var composedTimes = 0
+
+        var recomposeScope: RecomposeScope? = null
+
+        composition {
+            recomposeScope = currentRecomposeScope
+            composedTimes++
+            Button(attrs = { onClick { count++ } })
+        }
+
+        assertEquals(1, composedTimes)
+
+        val btn = root.firstChild as HTMLElement
+
+        btn.dispatchEvent(MouseEvent("click"))
+        assertEquals(1, count)
+
+        // This will force the update, thus it will cause the listeners being removed/added:
+        recomposeScope!!.invalidate()
+        waitForAnimationFrame()
+        assertEquals(2, composedTimes)
+
+        assertEquals(1, count)
+
+        btn.dispatchEvent(MouseEvent("click"))
+        assertEquals(2, count, "Removed listener should never be called")
+    }
+
+    @Test
+    fun removedEventListenersWithNotDefaultOptionsGetNeverCalled() = runTest {
+        var count = 0
+        var composedTimes = 0
+
+        var recomposeScope: RecomposeScope? = null
+
+        composition {
+            recomposeScope = currentRecomposeScope
+            composedTimes++
+            Button(attrs = { onClick(Options(passive = Options.BooleanValue.True)) { count++ } })
+        }
+
+        assertEquals(1, composedTimes)
+
+        val btn = root.firstChild as HTMLElement
+
+        btn.dispatchEvent(MouseEvent("click"))
+        assertEquals(1, count)
+
+        // This will force the update, thus it will cause the listeners being removed/added:
+        recomposeScope!!.invalidate()
+        waitForAnimationFrame()
+        assertEquals(2, composedTimes)
+
+        assertEquals(1, count)
+
+        btn.dispatchEvent(MouseEvent("click"))
+        assertEquals(2, count, "Removed listener should never be called")
+    }
+
+    @Test
+    fun captureOptionEnsuresCorrectOrderOfListeners() = runTest {
+        var callOrder = ""
+
+        composition {
+            Div(attrs = {
+                onClick(options = Options(capture = Options.BooleanValue.True)) {
+                    callOrder += "1"
+                }
+            }) {
+                Div(attrs = {
+                    onClick(options = Options(capture = Options.BooleanValue.True)) {
+                        callOrder += "2"
+                    }
+                }) {
+                    P(attrs = {
+                        onClick {
+                            callOrder += "3"
+                        }
+                    }) { Text("SomeText") }
+                }
+            }
+        }
+
+        val paragraph = root.firstChild!!.firstChild!!.firstChild as HTMLParagraphElement
+        paragraph.dispatchEvent(MouseEvent("click"))
+
+        assertEquals("123", callOrder)
     }
 
     @Test


### PR DESCRIPTION
There are 3 parameters in Options
```kotlin
class Options(
    val capture: BooleanValue = BooleanValue.Default,
    val once: BooleanValue = BooleanValue.Default,
    val passive: BooleanValue = BooleanValue.Default,
)
```

Usage example:
```kotlin
onClick(options = Options(capture = Options.BooleanValue.True)) {
      ...
}
```