### PR TITLE
web: Remove deprecated input event listeners

### DIFF
--- a/web/benchmark-core/src/jsMain/kotlin/com/sample/content/CodeSamplesSwitcher.kt
+++ b/web/benchmark-core/src/jsMain/kotlin/com/sample/content/CodeSamplesSwitcher.kt
@@ -75,7 +75,7 @@ fun CodeSampleSwitcher(count: Int, current: Int, onSelect: (Int) -> Unit) {
                 value("snippet$ix")
                 id("snippet$ix")
                 if (current == ix) checked()
-                onRadioInput { onSelect(ix) }
+                onInput { onSelect(ix) }
             })
             Label(forId = "snippet$ix") { Text("${ix + 1}") }
         }

--- a/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/InputAttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/InputAttrsBuilder.kt
@@ -5,11 +5,9 @@
 
 package androidx.compose.web.attributes
 
-import org.jetbrains.compose.web.attributes.*
-import org.jetbrains.compose.web.events.GenericWrappedEvent
-import org.jetbrains.compose.web.events.WrappedCheckBoxInputEvent
-import org.jetbrains.compose.web.events.WrappedRadioInputEvent
-import org.jetbrains.compose.web.events.WrappedTextInputEvent
+import org.jetbrains.compose.web.attributes.AttrsBuilder
+import org.jetbrains.compose.web.attributes.InputType
+import org.jetbrains.compose.web.attributes.Options
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.events.Event
@@ -44,50 +42,5 @@ class InputAttrsBuilder<T>(val inputType: InputType<T>) : AttrsBuilder<HTMLInput
             val value = inputType.inputValue(it.nativeEvent)
             listener(SyntheticInputEvent(value, it.nativeEvent.target as HTMLInputElement, it.nativeEvent))
         }
-    }
-
-    @Deprecated(
-        message = "It's not reliable as it can be applied to any input type.",
-        replaceWith = ReplaceWith("onInput(options, listener)"),
-        level = DeprecationLevel.WARNING
-    )
-    fun onTextInput(options: Options = Options.DEFAULT, listener: (WrappedTextInputEvent) -> Unit) {
-        listeners.add(TextInputEventListener(options, listener))
-    }
-
-    @Deprecated(
-        message = "It's not reliable as it can be applied to any input type.",
-        replaceWith = ReplaceWith("onInput(options, listener)"),
-        level = DeprecationLevel.WARNING
-    )
-    fun onCheckboxInput(
-        options: Options = Options.DEFAULT,
-        listener: (WrappedCheckBoxInputEvent) -> Unit
-    ) {
-        listeners.add(CheckBoxInputEventListener(options, listener))
-    }
-
-    @Deprecated(
-        message = "It's not reliable as it can be applied to any input type.",
-        replaceWith = ReplaceWith("onInput(options, listener)"),
-        level = DeprecationLevel.WARNING
-    )
-    fun onRadioInput(
-        options: Options = Options.DEFAULT,
-        listener: (WrappedRadioInputEvent) -> Unit
-    ) {
-        listeners.add(RadioInputEventListener(options, listener))
-    }
-
-    @Deprecated(
-        message = "It's not reliable as it can be applied to any input type.",
-        replaceWith = ReplaceWith("onInput(options, listener)"),
-        level = DeprecationLevel.WARNING
-    )
-    fun onRangeInput(
-        options: Options = Options.DEFAULT,
-        listener: (GenericWrappedEvent<*>) -> Unit
-    ) {
-        listeners.add(WrappedEventListener(INPUT, options, listener))
     }
 }

--- a/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/TextAreaAttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/androidx/compose/web/attributes/TextAreaAttrsBuilder.kt
@@ -5,8 +5,8 @@
 
 package androidx.compose.web.attributes
 
-import org.jetbrains.compose.web.attributes.*
-import org.jetbrains.compose.web.events.WrappedTextInputEvent
+import org.jetbrains.compose.web.attributes.AttrsBuilder
+import org.jetbrains.compose.web.attributes.Options
 import org.w3c.dom.HTMLTextAreaElement
 
 class TextAreaAttrsBuilder : AttrsBuilder<HTMLTextAreaElement>() {
@@ -19,14 +19,5 @@ class TextAreaAttrsBuilder : AttrsBuilder<HTMLTextAreaElement>() {
             val text = it.nativeEvent.target.asDynamic().value.unsafeCast<String>()
             listener(SyntheticInputEvent(text, it.nativeEvent.target as HTMLTextAreaElement, it.nativeEvent))
         }
-    }
-
-    @Deprecated(
-        message = "It's not reliable as it can be applied to any input type.",
-        replaceWith = ReplaceWith("onInput(options, listener)"),
-        level = DeprecationLevel.WARNING
-    )
-    fun onTextInput(options: Options = Options.DEFAULT, listener: (WrappedTextInputEvent) -> Unit) {
-        listeners.add(TextInputEventListener(options, listener))
     }
 }

--- a/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/CodeSnippetSamples.kt
+++ b/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/CodeSnippetSamples.kt
@@ -33,7 +33,7 @@ fun KotlinCodeSnippets() {
             type = InputType.Radio,
             attrs = {
                 name("code-snippet")
-                onRadioInput {
+                onInput {
                     currentSnippet.value = """
                         /* Adds two integers */
                         fun add(i: Int, j: Int): Int {
@@ -47,7 +47,7 @@ fun KotlinCodeSnippets() {
             type = InputType.Radio,
             attrs = {
                 name("code-snippet")
-                onRadioInput {
+                onInput {
                     currentSnippet.value = """
                         /* Does some calculations */
                         fun calculate(i: Int, j: Int): Int {

--- a/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/Sample.kt
+++ b/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/Sample.kt
@@ -272,8 +272,8 @@ fun MyInputComponent(text: State<String>, onChange: (String) -> Unit) {
                 onKeyDown {
                     println("On keyDown key = : ${it.getNormalizedKey()}")
                 }
-                onTextInput {
-                    onChange(it.inputValue)
+                onInput {
+                    onChange(it.value)
                 }
                 onKeyUp {
                     println("On keyUp key = : ${it.getNormalizedKey()}")
@@ -283,8 +283,8 @@ fun MyInputComponent(text: State<String>, onChange: (String) -> Unit) {
     }
     Div {
         Input(type = InputType.Checkbox, attrs = {
-            onCheckboxInput {
-                println("From div - Checked: " + it.checked)
+            onInput {
+                println("From div - Checked: " + it.value)
             }
         })
         Input(type = InputType.Text, attrs = {
@@ -295,8 +295,8 @@ fun MyInputComponent(text: State<String>, onChange: (String) -> Unit) {
         Input(
             type = InputType.Radio,
             attrs = {
-                onRadioInput {
-                    println("Radio 1 - Checked: " + it.checked)
+                onInput {
+                    println("Radio 1 - Checked: " + it.value)
                 }
                 name("f1")
             }
@@ -304,8 +304,8 @@ fun MyInputComponent(text: State<String>, onChange: (String) -> Unit) {
         Input(
             type = InputType.Radio,
             attrs = {
-                onRadioInput {
-                    println("Radio 2 - Checked: " + it.checked)
+                onInput {
+                    println("Radio 2 - Checked: " + it.value)
                 }
                 name("f1")
             }

--- a/web/widgets/src/jsMain/kotlin/layouts/slider.kt
+++ b/web/widgets/src/jsMain/kotlin/layouts/slider.kt
@@ -24,9 +24,8 @@ actual fun SliderActual(
             attr("min", valueRange.start.toString())
             attr("max", valueRange.endInclusive.toString())
             attr("step", step.toString())
-            onRangeInput {
-                val value: String = it.nativeEvent.target.asDynamic().value
-                onValueChange(value.toFloat())
+            onInput {
+                onValueChange(it.value?.toFloat() ?: 0f)
             }
         }
     )


### PR DESCRIPTION
this PR removes deprecated input events listeners:

- onTextInput
- onCheckboxInput
- onRadioInput
- onRangeInput

The new method `onInput {}` covers all the use cases. 