### PR TITLE
Proof of concept for newer CSS API

### DIFF
--- a/web/benchmark-core/src/jsMain/kotlin/com/sample/style/WtCard.kt
+++ b/web/benchmark-core/src/jsMain/kotlin/com/sample/style/WtCard.kt
@@ -11,7 +11,6 @@ import org.jetbrains.compose.web.css.alignItems
 import org.jetbrains.compose.web.css.backgroundColor
 import org.jetbrains.compose.web.css.border
 import org.jetbrains.compose.web.css.color
-import org.jetbrains.compose.web.css.display
 import org.jetbrains.compose.web.css.flexDirection
 import org.jetbrains.compose.web.css.flexGrow
 import org.jetbrains.compose.web.css.maxWidth

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
@@ -113,6 +113,12 @@ open class StyleBuilderImpl : StyleBuilder, StyleHolder {
     }
 }
 
+open class NamedProperty(private val delegate: StyleBuilder, private val name: String) : StyleBuilderImpl(), StyleBuilder by delegate{
+    fun property(value: String) {
+        property(name, value)
+    }
+}
+
 data class StylePropertyDeclaration(
     val name: String,
     val value: StylePropertyValue

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/properties.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/properties.kt
@@ -13,7 +13,42 @@ fun StyleBuilder.opacity(value: CSSSizeValue<CSSUnit.percent>) {
     property("opacity", (value.value / 100))
 }
 
-fun StyleBuilder.display(displayStyle: DisplayStyle) {
-    property("display", displayStyle.value)
+interface DisplayProperty  {
+    fun block()
+    fun contents()
+    fun flex()
+    fun grid()
+    fun inherit()
+    fun initial()
+    fun inlineBlock()
+    fun inline()
+    fun legacyFlowRoot()
+    fun legacyInlineFlex()
+    fun legacyInlineGrid()
+    fun listItem()
+    fun none()
+    fun table()
+    fun tableRow()
+    fun unset()
 }
+
+val StyleBuilder.display: DisplayProperty
+    get() = object : NamedProperty(this, "display"), DisplayProperty {
+        override fun block() = property("block")
+        override fun contents() = property("contents")
+        override fun flex() = property("flex")
+        override fun grid() = property("grid")
+        override fun inherit() = property("inherit")
+        override fun initial() = property("initial")
+        override fun inlineBlock() = property("inline-block")
+        override fun inline() = property("inline")
+        override fun legacyFlowRoot() = property("flow-root")
+        override fun legacyInlineFlex() = property("inline-flex")
+        override fun legacyInlineGrid() = property("inline-grid")
+        override fun listItem() = property("list-item")
+        override fun none() = property("none")
+        override fun table() = property("table")
+        override fun tableRow() = property("table-row")
+        override fun unset() = property("unset")
+    }
 

--- a/web/core/src/jsTest/kotlin/StaticComposableTests.kt
+++ b/web/core/src/jsTest/kotlin/StaticComposableTests.kt
@@ -258,24 +258,6 @@ class StaticComposableTests {
     }
 
     @Test
-    fun stylesWidth() {
-        val root = "div".asHtmlElement()
-        renderComposable(
-            root = root
-        ) {
-            Div(
-                {
-                    style {
-                        width(100.px)
-                    }
-                }
-            )
-        }
-
-        assertEquals("width: 100px;", (root.children[0] as HTMLElement).style.cssText)
-    }
-
-    @Test
     fun stylesBorderRadius() {
         val root = "div".asHtmlElement()
         renderComposable(
@@ -422,24 +404,6 @@ class StaticComposableTests {
 
         assertEquals("right: 100px;", (root.children[0] as HTMLElement).style.cssText)
         assertEquals("right: 100%;", (root.children[1] as HTMLElement).style.cssText)
-    }
-
-    @Test
-    fun stylesHeight() {
-        val root = "div".asHtmlElement()
-        renderComposable(
-            root = root
-        ) {
-            Div(
-                {
-                    style {
-                        height(100.px)
-                    }
-                }
-            )
-        }
-
-        assertEquals("height: 100px;", (root.children[0] as HTMLElement).style.cssText)
     }
 
     @Test

--- a/web/core/src/jsTest/kotlin/StaticComposableTests.kt
+++ b/web/core/src/jsTest/kotlin/StaticComposableTests.kt
@@ -16,13 +16,11 @@ import org.jetbrains.compose.web.css.border
 import org.jetbrains.compose.web.css.borderRadius
 import org.jetbrains.compose.web.css.bottom
 import org.jetbrains.compose.web.css.color
-import org.jetbrains.compose.web.css.display
 import org.jetbrains.compose.web.css.flexDirection
 import org.jetbrains.compose.web.css.flexFlow
 import org.jetbrains.compose.web.css.flexGrow
 import org.jetbrains.compose.web.css.flexShrink
 import org.jetbrains.compose.web.css.flexWrap
-import org.jetbrains.compose.web.css.height
 import org.jetbrains.compose.web.css.justifyContent
 import org.jetbrains.compose.web.css.left
 import org.jetbrains.compose.web.css.opacity
@@ -33,7 +31,6 @@ import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.right
 import org.jetbrains.compose.web.css.top
 import org.jetbrains.compose.web.css.value
-import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Span
 import org.jetbrains.compose.web.dom.Text
@@ -404,32 +401,6 @@ class StaticComposableTests {
 
         assertEquals("right: 100px;", (root.children[0] as HTMLElement).style.cssText)
         assertEquals("right: 100%;", (root.children[1] as HTMLElement).style.cssText)
-    }
-
-    @Test
-    fun stylesDisplay() {
-        val root = "div".asHtmlElement()
-        val enumValues = DisplayStyle.values()
-        renderComposable(
-            root = root
-        ) {
-            enumValues.forEach { displayStyle ->
-                Div(
-                    {
-                        style {
-                            display(displayStyle)
-                        }
-                    }
-                ) { }
-            }
-        }
-
-        enumValues.forEachIndexed { index, displayStyle ->
-            assertEquals(
-                "display: ${displayStyle.value};",
-                (root.children[index] as HTMLElement).style.cssText
-            )
-        }
     }
 
     @Test

--- a/web/core/src/jsTest/kotlin/css/CSSBoxTests.kt
+++ b/web/core/src/jsTest/kotlin/css/CSSBoxTests.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.web.core.tests.css
+
+import org.jetbrains.compose.web.core.tests.asHtmlElement
+import org.jetbrains.compose.web.core.tests.runTest
+import org.jetbrains.compose.web.css.height
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.css.width
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.renderComposable
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.get
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CSSBoxTests {
+
+    @Test
+    fun stylesWidth() = runTest {
+        composition {
+            Div(
+                {
+                    style {
+                        width(100.px)
+                    }
+                }
+            )
+        }
+
+        assertEquals("100px", (root.children[0] as HTMLElement).style.width)
+    }
+
+    @Test
+    fun stylesHeight() = runTest {
+        composition {
+            Div(
+                {
+                    style {
+                        height(90.px)
+                    }
+                }
+            )
+        }
+
+        assertEquals("90px", (root.children[0] as HTMLElement).style.height)
+    }
+
+}

--- a/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
+++ b/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020-2021 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.web.core.tests.css
+
+import org.jetbrains.compose.web.core.tests.runTest
+import org.jetbrains.compose.web.core.tests.values
+import org.jetbrains.compose.web.css.DisplayStyle
+import org.jetbrains.compose.web.css.display
+import org.jetbrains.compose.web.css.value
+import org.jetbrains.compose.web.dom.Div
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.get
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CSSDisplayTests {
+
+    @Test
+    fun stylesDisplay() = runTest {
+        val enumValues = DisplayStyle.values()
+
+        composition {
+            enumValues.forEach { displayStyle ->
+                Div(
+                    {
+                        style {
+                            display(displayStyle)
+                        }
+                    }
+                )
+            }
+        }
+
+        enumValues.forEachIndexed { index, displayStyle ->
+            assertEquals(
+                displayStyle.value,
+                (root.children[index] as HTMLElement).style.display
+            )
+        }
+    }
+
+}

--- a/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
+++ b/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
@@ -6,10 +6,7 @@
 package org.jetbrains.compose.web.core.tests.css
 
 import org.jetbrains.compose.web.core.tests.runTest
-import org.jetbrains.compose.web.core.tests.values
-import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.display
-import org.jetbrains.compose.web.css.value
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
@@ -20,26 +17,42 @@ class CSSDisplayTests {
 
     @Test
     fun stylesDisplay() = runTest {
-        val enumValues = DisplayStyle.values()
 
         composition {
-            enumValues.forEach { displayStyle ->
-                Div(
-                    {
-                        style {
-                            display(displayStyle)
-                        }
-                    }
-                )
-            }
+            Div({ style { display.block() } })
+            Div({ style { display.contents() } })
+            Div({ style { display.flex() } })
+            Div({ style { display.grid() } })
+            Div({ style { display.inherit() } })
+            Div({ style { display.initial() } })
+            Div({ style { display.inlineBlock() } })
+            Div({ style { display.inline() } })
+            Div({ style { display.legacyFlowRoot() } })
+            Div({ style { display.legacyInlineFlex() } })
+            Div({ style { display.legacyInlineGrid() } })
+            Div({ style { display.listItem() } })
+            Div({ style { display.none() } })
+            Div({ style { display.table() } })
+            Div({ style { display.tableRow() } })
+            Div({ style { display.unset() } })
         }
 
-        enumValues.forEachIndexed { index, displayStyle ->
-            assertEquals(
-                displayStyle.value,
-                (root.children[index] as HTMLElement).style.display
-            )
-        }
+        assertEquals("block", (root.children[0] as HTMLElement).style.display)
+        assertEquals("contents", (root.children[1] as HTMLElement).style.display)
+        assertEquals("flex", (root.children[2] as HTMLElement).style.display)
+        assertEquals("grid", (root.children[3] as HTMLElement).style.display)
+        assertEquals("inherit", (root.children[4] as HTMLElement).style.display)
+        assertEquals("initial", (root.children[5] as HTMLElement).style.display)
+        assertEquals("inline-block", (root.children[6] as HTMLElement).style.display)
+        assertEquals("inline", (root.children[7] as HTMLElement).style.display)
+        assertEquals("flow-root", (root.children[8] as HTMLElement).style.display)
+        assertEquals("inline-flex", (root.children[9] as HTMLElement).style.display)
+        assertEquals("inline-grid", (root.children[10] as HTMLElement).style.display)
+        assertEquals("list-item", (root.children[11] as HTMLElement).style.display)
+        assertEquals("none", (root.children[12] as HTMLElement).style.display)
+        assertEquals("table", (root.children[13] as HTMLElement).style.display)
+        assertEquals("table-row", (root.children[14] as HTMLElement).style.display)
+        assertEquals("unset", (root.children[15] as HTMLElement).style.display)
     }
 
 }

--- a/web/widgets/src/jsMain/kotlin/Styles.kt
+++ b/web/widgets/src/jsMain/kotlin/Styles.kt
@@ -6,7 +6,6 @@ import org.jetbrains.compose.web.css.alignItems
 import org.jetbrains.compose.web.css.AlignItems
 import org.jetbrains.compose.web.css.flexDirection
 import org.jetbrains.compose.web.css.FlexDirection
-import org.jetbrains.compose.web.css.display
 import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.left
 import org.jetbrains.compose.web.css.px


### PR DESCRIPTION
The idea is to get rid of existing API calls where we try to mimick one-slot string union type values via enum.
Instead it is supposed to use specialized methods.

This is proof of concept, we also have inline vals as in CSSEnums and the idea is to choose the best syntax based on what will generate smaller bundles. 

However it give idea what we are up to (regardless of what syntax we'll choose - it won't affect the API we are providing for users).