### PR TITLE
web: fix a bug for inputs taking string value

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/InputElements.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/InputElements.kt
@@ -9,7 +9,7 @@ private fun InputAttrsBuilder<String>.applyAttrsWithStringValue(
     value: String,
     attrsBuilder: InputAttrsBuilder<String>.() -> Unit
 ) {
-    if (value.isNotEmpty()) value(value)
+    value(value)
     attrsBuilder()
 }
 

--- a/web/core/src/jsTest/kotlin/elements/InputsGenerateCorrectHtmlTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/InputsGenerateCorrectHtmlTests.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
 import org.jetbrains.compose.web.attributes.*
 import org.jetbrains.compose.web.core.tests.runTest
+import org.jetbrains.compose.web.core.tests.waitForAnimationFrame
 import org.jetbrains.compose.web.dom.*
 import org.w3c.dom.HTMLInputElement
+import org.w3c.dom.HTMLTextAreaElement
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -436,5 +438,69 @@ class InputsGenerateCorrectHtmlTests {
             })
         }
         assertEquals("""<select autocomplete="tel"></select>""", root.innerHTML)
+    }
+
+    @Test
+    fun textInputChangesItsValueFromTextToEmpty() = runTest {
+        var state by mutableStateOf("text")
+
+        composition {
+            TextInput(value = state)
+        }
+
+        assertEquals("text", (root.firstChild as HTMLInputElement).value)
+
+        state = ""
+        waitForAnimationFrame()
+
+        assertEquals("", (root.firstChild as HTMLInputElement).value)
+    }
+
+    @Test
+    fun textInputChangesItsValueFromEmptyToText() = runTest {
+        var state by mutableStateOf("")
+
+        composition {
+            TextInput(value = state)
+        }
+
+        assertEquals("", (root.firstChild as HTMLInputElement).value)
+
+        state = "text"
+        waitForAnimationFrame()
+
+        assertEquals("text", (root.firstChild as HTMLInputElement).value)
+    }
+
+    @Test
+    fun textAreaChangesItsValueFromTextToEmpty() = runTest {
+        var state by mutableStateOf("text")
+
+        composition {
+            TextArea(value = state)
+        }
+
+        assertEquals("text", (root.firstChild as HTMLTextAreaElement).value)
+
+        state = ""
+        waitForAnimationFrame()
+
+        assertEquals("", (root.firstChild as HTMLTextAreaElement).value)
+    }
+
+    @Test
+    fun textAreaChangesItsValueFromEmptyToText() = runTest {
+        var state by mutableStateOf("")
+
+        composition {
+            TextArea(value = state)
+        }
+
+        assertEquals("", (root.firstChild as HTMLTextAreaElement).value)
+
+        state = "text"
+        waitForAnimationFrame()
+
+        assertEquals("text", (root.firstChild as HTMLTextAreaElement).value)
     }
 }


### PR DESCRIPTION
It was not possible to make the input empty by setting the state to an empty string.

reported in slack: https://kotlinlang.slack.com/archives/C01F2HV7868/p1625821714406600