### PR TITLE
Suppress naming style inspection for composable functions

### DIFF
--- a/idea-plugin/src/main/kotlin/org/jetbrains/compose/inspections/ComposeSuppressor.kt
+++ b/idea-plugin/src/main/kotlin/org/jetbrains/compose/inspections/ComposeSuppressor.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.compose.inspections
+
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.psi.PsiElement
+import org.jetbrains.compose.desktop.ide.preview.isComposableFunction
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.lexer.KtTokens
+
+/**
+ * Suppress inspection that require composable function names to start with a lower case letter.
+ */
+class ComposeSuppressor : InspectionSuppressor {
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
+        return toolId == "FunctionName" &&
+                element.language == KotlinLanguage.INSTANCE &&
+                element.node.elementType == KtTokens.IDENTIFIER &&
+                element.parent.isComposableFunction()
+    }
+
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<SuppressQuickFix> {
+        return SuppressQuickFix.EMPTY_ARRAY
+    }
+}
+

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -36,5 +36,7 @@
                 factoryClass="org.jetbrains.compose.desktop.ide.preview.PreviewToolWindow"
                 id="Desktop Preview" doNotActivateOnStart="true"
                 anchor="right" />
+
+        <lang.inspectionSuppressor language="kotlin" implementationClass="org.jetbrains.compose.inspections.ComposeSuppressor"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
This change suppresses a diagnostic,
which complaints, when a function starts
with an upper case letter