### PR TITLE
Add a check that compose is used along with kotlinx.serialization

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -16,6 +16,7 @@ import org.jetbrains.compose.desktop.DesktopExtension
 import org.jetbrains.compose.desktop.application.internal.configureApplicationImpl
 import org.jetbrains.compose.desktop.application.internal.currentTarget
 import org.jetbrains.compose.desktop.preview.internal.initializePreview
+import org.jetbrains.compose.internal.checkAndWarnAboutComposeWithSerialization
 import org.jetbrains.compose.web.internal.initializeWeb
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -106,6 +107,8 @@ class ComposePlugin : Plugin<Project> {
                 useIR = true
             }
         }
+
+        project.checkAndWarnAboutComposeWithSerialization()
     }
 
     object Dependencies {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
@@ -1,28 +1,18 @@
 package org.jetbrains.compose.internal
 
 import org.gradle.api.Project
-import org.gradle.configurationcache.extensions.serviceOf
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 internal fun Project.checkAndWarnAboutComposeWithSerialization() {
-    afterEvaluate {
-        val usesKotlinxSerialization = configurations.names.asSequence().filter {
-            it.startsWith("kotlinCompilerPluginClasspath")
-        }.any { configurationName ->
-            configurations.getByName(configurationName).dependencies.any { dependency ->
-                dependency.name.contains("kotlin-serialization")
-            }
-        }
+    project.plugins.withId("org.jetbrains.kotlin.plugin.serialization") {
+        val warningMessage = """
 
-        if (usesKotlinxSerialization) {
-            val out = serviceOf<StyledTextOutputFactory>().create("COMPOSE_PLUGIN")
-            out.style(StyledTextOutput.Style.FailureHeader)
-                .text("WARNING! Both Compose and kotlinx.serialization plugins are used in the module '${project.name}'")
-                .println()
-                .style(StyledTextOutput.Style.Failure)
-                .text("Consider using these plugins in separate modules to avoid compilation errors")
-                .println()
-        }
+            >>> COMPOSE WARNING
+            >>> Project `${project.name}` has `compose` and `kotlinx.serialization` plugins applied!
+            >>> Consider using these plugins in separate modules to avoid compilation errors
+            >>> Check more details here: https://github.com/JetBrains/compose-jb
+
+        """.trimIndent()
+
+        logger.warn(warningMessage)
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
@@ -9,7 +9,7 @@ internal fun Project.checkAndWarnAboutComposeWithSerialization() {
             >>> COMPOSE WARNING
             >>> Project `${project.name}` has `compose` and `kotlinx.serialization` plugins applied!
             >>> Consider using these plugins in separate modules to avoid compilation errors
-            >>> Check more details here: https://github.com/JetBrains/compose-jb
+            >>> Check more details here: https://github.com/JetBrains/compose-jb/issues/738
 
         """.trimIndent()
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/WarnAboutComposeWithSerialization.kt
@@ -1,0 +1,28 @@
+package org.jetbrains.compose.internal
+
+import org.gradle.api.Project
+import org.gradle.configurationcache.extensions.serviceOf
+import org.gradle.internal.logging.text.StyledTextOutput
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+
+internal fun Project.checkAndWarnAboutComposeWithSerialization() {
+    afterEvaluate {
+        val usesKotlinxSerialization = configurations.names.asSequence().filter {
+            it.startsWith("kotlinCompilerPluginClasspath")
+        }.any { configurationName ->
+            configurations.getByName(configurationName).dependencies.any { dependency ->
+                dependency.name.contains("kotlin-serialization")
+            }
+        }
+
+        if (usesKotlinxSerialization) {
+            val out = serviceOf<StyledTextOutputFactory>().create("COMPOSE_PLUGIN")
+            out.style(StyledTextOutput.Style.FailureHeader)
+                .text("WARNING! Both Compose and kotlinx.serialization plugins are used in the module '${project.name}'")
+                .println()
+                .style(StyledTextOutput.Style.Failure)
+                .text("Consider using these plugins in separate modules to avoid compilation errors")
+                .println()
+        }
+    }
+}


### PR DESCRIPTION
There's a known issue that both plugins can't be used in the same module (specifically for kotlin/js targets).

We decided to make the problem more explicit by showing a message.
The compose gradle plugin will check for `kotlinx.serialization` and will show a warning.


@AlexeyTsvetkov  What do you think? Is there a more idiomatic way to solve such kind of task?
Thanks!