### PR TITLE
Include jdk.crypto.ec by default

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/NativeDistributions.kt
@@ -13,7 +13,7 @@ import java.util.*
 import javax.inject.Inject
 
 internal val DEFAULT_RUNTIME_MODULES = arrayOf(
-    "java.base", "java.desktop", "java.logging"
+    "java.base", "java.desktop", "java.logging", "jdk.crypto.ec"
 )
 
 open class NativeDistributions @Inject constructor(


### PR DESCRIPTION
Without this module most of https
is not going to work (see https://github.com/JetBrains/compose-jb/issues/269 or https://github.com/JetBrains/compose-jb/issues/429)

The inclusion of this module increases a size of
a prepackaged app by ~440 kb
and of a packaged dmg by ~167 kb