### PR TITLE
Sign jnilib files on osx

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
@@ -62,4 +62,4 @@ internal class MacJarSignFileCopyingProcessor(
 }
 
 private val String.isDylibPath
-    get() = endsWith(".dylib")
+    get() = endsWith(".dylib") || endsWith(".jnilib")


### PR DESCRIPTION
This should solve https://github.com/JetBrains/compose-jb/issues/959

`.jnilib` aren't being signed for mac builds, but I think they should be. I understand that `.jnilib` files are a deprecated format, but certain libraries still use them. Specifically I'm encountering  this problem when trying to use https://github.com/xerial/sqlite-jdbc and https://github.com/Willena/sqlite-jdbc-crypt