### PR TITLE
Allow preview to work without explicit dependency on compose.uiTooling

### DIFF
--- a/idea-plugin/examples/simple-preview-example/mpp-jvm/build.gradle.kts
+++ b/idea-plugin/examples/simple-preview-example/mpp-jvm/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
                 api(compose.runtime)
                 api(compose.foundation)
                 api(compose.material)
-                api(compose.uiTooling)
             }
         }
         named("desktopMain") {

--- a/idea-plugin/examples/simple-preview-example/pure-jvm/build.gradle.kts
+++ b/idea-plugin/examples/simple-preview-example/pure-jvm/build.gradle.kts
@@ -7,6 +7,4 @@ plugins {
 
 dependencies {
     implementation(compose.desktop.currentOs)
-    // todo: remove after update
-    implementation(compose.uiTooling)
 }


### PR DESCRIPTION
Add runtime-only module org.jetbrains.compose.ui:ui-tooling-desktop
to preview classpath in configureDesktopPreview task