### PR TITLE
Add compose.preview dependency shortcut

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -119,6 +119,7 @@ class ComposePlugin : Plugin<Project> {
         val runtime get() = composeDependency("org.jetbrains.compose.runtime:runtime")
         val ui get() = composeDependency("org.jetbrains.compose.ui:ui")
         val uiTooling get() = composeDependency("org.jetbrains.compose.ui:ui-tooling")
+        val preview get() = composeDependency("org.jetbrains.compose.ui:ui-tooling-preview")
         val materialIconsExtended get() = composeDependency("org.jetbrains.compose.material:material-icons-extended")
         val web: WebDependencies get() =
             if (ComposeBuildConfig.isComposeWithWeb) WebDependencies


### PR DESCRIPTION
Useful for MPP modules, that don't depend on compose.desktop.currentOs