### PR TITLE
Move TodoApp previews to compose-ui module

### DIFF
--- a/examples/todoapp/common/compose-ui/build.gradle.kts
+++ b/examples/todoapp/common/compose-ui/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.compose.compose
-
 plugins {
     id("multiplatform-compose-setup")
     id("android-setup")
@@ -14,12 +12,6 @@ kotlin {
                 implementation(project(":common:root"))
                 implementation(Deps.ArkIvanov.Decompose.decompose)
                 implementation(Deps.ArkIvanov.Decompose.extensionsCompose)
-            }
-        }
-
-        named("desktopMain") {
-            dependencies {
-                implementation(compose.uiTooling)
             }
         }
     }

--- a/examples/todoapp/common/compose-ui/build.gradle.kts
+++ b/examples/todoapp/common/compose-ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.compose.compose
+
 plugins {
     id("multiplatform-compose-setup")
     id("android-setup")
@@ -12,6 +14,12 @@ kotlin {
                 implementation(project(":common:root"))
                 implementation(Deps.ArkIvanov.Decompose.decompose)
                 implementation(Deps.ArkIvanov.Decompose.extensionsCompose)
+            }
+        }
+
+        named("desktopMain") {
+            dependencies {
+                implementation(compose.uiTooling)
             }
         }
     }

--- a/examples/todoapp/common/compose-ui/src/desktopMain/kotlin/example/todo/common/ui/TodoEditPreview.kt
+++ b/examples/todoapp/common/compose-ui/src/desktopMain/kotlin/example/todo/common/ui/TodoEditPreview.kt
@@ -1,8 +1,4 @@
-/*
- * Should be in the compose-ui module, see https://github.com/JetBrains/compose-jb/issues/908
- */
-
-package example.todo.desktop
+package example.todo.common.ui
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
@@ -10,7 +6,6 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import example.todo.common.edit.TodoEdit
 import example.todo.common.edit.TodoEdit.Model
-import example.todo.common.ui.TodoEditContent
 
 @Composable
 @Preview

--- a/examples/todoapp/common/compose-ui/src/desktopMain/kotlin/example/todo/common/ui/TodoMainPreview.kt
+++ b/examples/todoapp/common/compose-ui/src/desktopMain/kotlin/example/todo/common/ui/TodoMainPreview.kt
@@ -1,8 +1,4 @@
-/*
- * Should be in the compose-ui module, see https://github.com/JetBrains/compose-jb/issues/908
- */
-
-package example.todo.desktop
+package example.todo.common.ui
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.runtime.Composable
@@ -11,7 +7,6 @@ import com.arkivanov.decompose.value.Value
 import example.todo.common.main.TodoItem
 import example.todo.common.main.TodoMain
 import example.todo.common.main.TodoMain.Model
-import example.todo.common.ui.TodoMainContent
 
 @Preview
 @Composable

--- a/examples/todoapp/desktop/build.gradle.kts
+++ b/examples/todoapp/desktop/build.gradle.kts
@@ -25,11 +25,6 @@ kotlin {
                 implementation(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
                 implementation(Deps.Badoo.Reaktive.reaktive)
                 implementation(Deps.Badoo.Reaktive.coroutinesInterop)
-
-                // The dependencies below are required only for previews, see https://github.com/JetBrains/compose-jb/issues/908
-                implementation(compose.uiTooling)
-                implementation(project(":common:edit"))
-                implementation(project(":common:main"))
             }
         }
     }


### PR DESCRIPTION
The issue #908 is fixed and so previews can be moved to `compose-ui` module.