### PR TITLE
Fix warning caused by NPE in tests

### DIFF
--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/GradleTestNameGenerator.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/GradleTestNameGenerator.kt
@@ -8,7 +8,7 @@ package org.jetbrains.compose.test
 import org.junit.jupiter.api.DisplayNameGenerator
 
 class GradleTestNameGenerator : DisplayNameGenerator.Standard() {
-    private val gradleVersion = "[Gradle '${TestProperties.gradleVersionForTests}']"
+    private val gradleVersion = TestProperties.gradleVersionForTests?.let { "[Gradle '$it']" } ?: ""
 
     override fun generateDisplayNameForClass(testClass: Class<*>?): String =
         super.generateDisplayNameForClass(testClass) + gradleVersion

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProperties.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/TestProperties.kt
@@ -9,6 +9,6 @@ object TestProperties {
     val composeVersion: String
         get() = System.getProperty("compose.plugin.version")!!
 
-    val gradleVersionForTests: String
-        get() = System.getProperty("gradle.version.for.tests")!!
+    val gradleVersionForTests: String?
+        get() = System.getProperty("gradle.version.for.tests")
 }


### PR DESCRIPTION
There are two types of Gradle tests:
* integration tests (:compose:testGradle-<GRADLE_VERSION>);
* unit tests (:compose:test);

There is a custom test name generator (GradleTestNameGenerator),
which prints current version of Gradle for integration tests.
During unit tests execution, GradleTestNameGenerator failed
with NPE, because the 'gradle.version.for.tests' system property
was not set. NPE did not crash the test suite,
but it was printed to stderr.