### PR TITLE
Fix compose web examples source code links

### DIFF
--- a/examples/web-landing/src/jsMain/kotlin/com/sample/content/GetStartedSection.kt
+++ b/examples/web-landing/src/jsMain/kotlin/com/sample/content/GetStartedSection.kt
@@ -42,7 +42,7 @@ private fun getCards(): List<GetStartedCardPresentation> {
             links = listOf(
                 LinkOnCard(
                     linkText = "Explore the source code",
-                    linkUrl = "https://github.com/JetBrains/compose-jb/tree/master/examples/falling_balls_with_web"
+                    linkUrl = "https://github.com/JetBrains/compose-jb/tree/master/examples/falling-balls-web"
                 ),
                 LinkOnCard(
                     linkText = "Play",

--- a/examples/web-landing/src/jsMain/kotlin/com/sample/content/GetStartedSection.kt
+++ b/examples/web-landing/src/jsMain/kotlin/com/sample/content/GetStartedSection.kt
@@ -32,7 +32,7 @@ private fun getCards(): List<GetStartedCardPresentation> {
             links = listOf(
                 LinkOnCard(
                     linkText = "Explore the source code",
-                    linkUrl = "https://github.com/JetBrains/compose-jb/tree/master/examples/web_landing"
+                    linkUrl = "https://github.com/JetBrains/compose-jb/tree/master/examples/web-landing"
                 )
             )
         ),


### PR DESCRIPTION
[Web landing](https://github.com/JetBrains/compose-jb/tree/master/examples/web_landing) and [falling balls](https://github.com/JetBrains/compose-jb/tree/master/examples/falling_balls_with_web) source code links were incorrect. Replace it with working ones: [web landing](https://github.com/JetBrains/compose-jb/tree/master/examples/web-landing), [falling balls](https://github.com/JetBrains/compose-jb/tree/master/examples/falling-balls-web)