### PR TITLE
Fix VideoPlayer

### DIFF
--- a/components/VideoPlayer/demo/src/jvmMain/kotlin/org/jetbrains/compose/videoplayer/demo/Main.kt
+++ b/components/VideoPlayer/demo/src/jvmMain/kotlin/org/jetbrains/compose/videoplayer/demo/Main.kt
@@ -13,7 +13,11 @@ fun main() {
     ) {
         MaterialTheme {
             DesktopTheme {
-                VideoPlayer("/System/Library/Compositions/Yosemite.mov", 640, 480)
+                VideoPlayer(
+                    url = "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+                    width = 640,
+                    height = 480
+                )
             }
         }
     }

--- a/components/VideoPlayer/library/src/desktopMain/kotlin/org/jetbrains/compose/videoplayer/DesktopVideoPlayer.kt
+++ b/components/VideoPlayer/library/src/desktopMain/kotlin/org/jetbrains/compose/videoplayer/DesktopVideoPlayer.kt
@@ -1,22 +1,31 @@
 package org.jetbrains.compose.videoplayer
 
-import androidx.compose.desktop.SwingPanel
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
 import uk.co.caprica.vlcj.factory.discovery.NativeDiscovery
+import uk.co.caprica.vlcj.player.base.MediaPlayer
+import uk.co.caprica.vlcj.player.component.CallbackMediaPlayerComponent
 import uk.co.caprica.vlcj.player.component.EmbeddedMediaPlayerComponent
+import java.util.*
+
 
 @Composable
 internal actual fun VideoPlayerImpl(url: String, width: Int, height: Int) {
     println("Video player for $url")
     NativeDiscovery().discover()
-    // Doesn't work on macOS, see https://github.com/caprica/vlcj/issues/887 for suggestions.
-    val mediaPlayerComponent = remember { EmbeddedMediaPlayerComponent() }
+    val mediaPlayerComponent = remember {
+        // see https://github.com/caprica/vlcj/issues/887#issuecomment-503288294 for why we're using CallbackMediaPlayerComponent for macOS.
+        if (isMacOS()) {
+            CallbackMediaPlayerComponent()
+        } else {
+            EmbeddedMediaPlayerComponent()
+        }
+    }
     SideEffect {
         val ok = mediaPlayerComponent.mediaPlayer().media().play(url)
         println("play gave $ok")
@@ -28,4 +37,22 @@ internal actual fun VideoPlayerImpl(url: String, width: Int, height: Int) {
             mediaPlayerComponent
         }
     )
+}
+
+/**
+ * To return mediaPlayer from player components.
+ * The method names are same, but they don't share the same parent/interface.
+ * That's why need this method.
+ */
+private fun Any.mediaPlayer(): MediaPlayer {
+    return when (this) {
+        is CallbackMediaPlayerComponent -> mediaPlayer()
+        is EmbeddedMediaPlayerComponent -> mediaPlayer()
+        else -> throw IllegalArgumentException("You can only call mediaPlayer() on vlcj player component")
+    }
+}
+
+private fun isMacOS(): Boolean {
+    val os = System.getProperty("os.name", "generic").lowercase(Locale.ENGLISH)
+    return os.indexOf("mac") >= 0 || os.indexOf("darwin") >= 0
 }


### PR DESCRIPTION
# Changes

This PR fixes two issues with the `VideoPlayer` sample.

## 🐛   No Video Issue

**Problem:**
- Previously, we were using  `vlcj`'s `EmbeddedMediaPlayerComponent` to play the video. This component doesn't work on macOS due to insufficient support from the `AWT` side. [[1]](https://stackoverflow.com/a/59346015/4370279)[[2]](https://github.com/caprica/vlcj/issues/887#issuecomment-503288294). This caused the player not to play the video on MacOS.

**Solution:**

- Check the OS type and provide `EmbeddedMediaPlayerComponent`  or `CallbackMediaPlayerComponent`(for macOS) accordingly. (here's the commit https://github.com/JetBrains/compose-jb/commit/1e396c79e01d7162e522c5fc3a92e52b1560e238)

## 🐛   Local file path Issue

**Problem:**
Previously, the URL was a local file path that wouldn't exist in every system.

**Solution:**
Update it to a public URL. Here's the commit (4366a6ea1aae6393879e7c9589fa9386176ee1fa)

# Output


https://user-images.githubusercontent.com/9678279/130316868-19d78267-db95-4bd3-be7d-52037935b8ae.mp4


