### PR TITLE
web: add tests for ComposableLambdaCalls.kt

### DIFF
--- a/web/compose-compiler-integration/src/jsMain/kotlin/CrossmoduleTestsDependencies.kt
+++ b/web/compose-compiler-integration/src/jsMain/kotlin/CrossmoduleTestsDependencies.kt
@@ -1,6 +1,7 @@
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import kotlinx.browser.document
+import org.jetbrains.compose.web.dom.Text
 
 data class DataClassTakesValComposable(val c: @Composable () -> Unit)
 data class DataClassTakesValComposableTyped<T>(val c: @Composable (T) -> Unit)
@@ -85,4 +86,8 @@ class ClassSavesStringAndComposableIntoVar(
 ) {
     var composableVar: @Composable ClassSavesStringAndComposableIntoVar.() -> Unit = c
     var stringVar: String = s
+}
+
+val GlobalComposableLambdaToShowText: @Composable (text: () -> String) -> Unit = {
+    Text(it())
 }

--- a/web/compose-compiler-integration/src/jsTest/kotlin/ComposableLambdaCalls.kt
+++ b/web/compose-compiler-integration/src/jsTest/kotlin/ComposableLambdaCalls.kt
@@ -1,0 +1,141 @@
+import androidx.compose.runtime.Composable
+import kotlinx.browser.document
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Text
+import org.jetbrains.compose.web.renderComposableInBody
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ComposableLambdaCalls {
+
+    @Composable
+    private fun ComposableSomeText(someText : () -> String) {
+        Text(someText())
+    }
+
+    private fun someText(): String {
+        return "SomeText"
+    }
+
+    @Test
+    fun passingFunctionReference() {
+        renderComposableInBody {
+            Div {
+                ComposableSomeText(::someText)
+            }
+        }
+
+        assertEquals("<div>SomeText</div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+
+    @Test
+    fun passingAnonymousLambda() {
+        renderComposableInBody {
+            Div {
+                ComposableSomeText { "Text1" }
+            }
+        }
+
+        assertEquals("<div>Text1</div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+
+    @Test
+    fun callingComposableLambdaWithoutArguments() {
+        val l: @Composable () -> Unit = {
+            Text("TextA")
+        }
+
+        renderComposableInBody {
+            Div {
+                l()
+            }
+        }
+
+        assertEquals("<div>TextA</div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+
+    @Test
+    fun invokingNullComposableLambdaWithoutArguments() {
+        val l: (@Composable () -> Unit)? = null
+
+        renderComposableInBody {
+            Div {
+                l?.invoke()
+            }
+        }
+
+        assertEquals("<div></div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+
+    @Test
+    fun invokingNullComposableLambdaWithArguments() {
+        val l: (@Composable (Int) -> Unit)? = null
+
+        var someIntInvoked = false
+
+        fun someInt(): Int {
+            someIntInvoked = true
+            return 10
+        }
+
+        renderComposableInBody {
+            Div {
+                l?.invoke(someInt())
+            }
+        }
+
+        assertEquals("<div></div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals(false, someIntInvoked, message = "someInt() should never be invoked as `l` is null")
+    }
+
+    @Test
+    fun invokingComposableLambdaWithArguments() {
+        val l: (@Composable (Int) -> Unit) = {
+            Text("Text$it")
+        }
+
+        var someIntInvoked = false
+
+        fun someInt(): Int {
+            someIntInvoked = true
+            return 10
+        }
+
+        renderComposableInBody {
+            Div {
+                l.invoke(someInt())
+            }
+        }
+
+        assertEquals("<div>Text10</div>", document.body!!.firstElementChild!!.outerHTML)
+        assertEquals(true, someIntInvoked)
+    }
+
+    @Test
+    fun invokingComposableLambdaWithFunctionReferenceAsArgument() {
+        val l: (@Composable (() -> String) -> Unit) = {
+            Text("Text-${it()}")
+        }
+
+        renderComposableInBody {
+            Div {
+                l.invoke(::someText)
+            }
+        }
+
+        assertEquals("<div>Text-SomeText</div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+
+    @Test
+    fun invokingComposableLambdaFromAnotherModule() {
+        renderComposableInBody {
+            Div {
+                GlobalComposableLambdaToShowText {
+                    "SuperText"
+                }
+            }
+        }
+
+        assertEquals("<div>SuperText</div>", document.body!!.firstElementChild!!.outerHTML)
+    }
+}

--- a/web/gradle.properties
+++ b/web/gradle.properties
@@ -1,6 +1,6 @@
 # __LATEST_COMPOSE_RELEASE_VERSION__
-COMPOSE_CORE_VERSION=1.0.0-alpha4-build328
-COMPOSE_WEB_VERSION=1.0.0-alpha4-build328
+COMPOSE_CORE_VERSION=1.0.0-alpha4-build348
+COMPOSE_WEB_VERSION=1.0.0-alpha4-build348
 compose.web.buildSamples=false
 compose.web.tests.integration.withFirefox
 compose.web.tests.skip.benchmarks=false


### PR DESCRIPTION
The tests are failing at the moment because there is no published compose plugin that includes fixes.
I tested it locally using mavenLocal()

It makes sense to update the compose core version first (as soon as it's available) and then to merge this PR.