### PR TITLE
web: add `testUtils` alias to gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -153,6 +153,10 @@ class ComposePlugin : Plugin<Project> {
         val widgets by lazy {
             composeDependency("org.jetbrains.compose.web:web-widgets")
         }
+
+        val testUtils by lazy {
+            composeDependency("org.jetbrains.compose.web:test-utils")
+        }
     }
 }
 


### PR DESCRIPTION
This will allow to use the dependency like this:
`compose.web.testUtils`