### PR TITLE
update web examples to workaround a bug when using `jsRun`

### DIFF
--- a/examples/falling-balls-web/build.gradle.kts
+++ b/examples/falling-balls-web/build.gradle.kts
@@ -77,7 +77,7 @@ compose.desktop {
 
 // a temporary workaround for a bug in jsRun invocation - see https://youtrack.jetbrains.com/issue/KT-48273
 afterEvaluate {
-    extensions.configure<NodeJsRootExtension> {
+    rootProject.extensions.configure<NodeJsRootExtension> {
         versions.webpackDevServer.version = "4.0.0"
     }
 }

--- a/examples/todoapp/web/build.gradle.kts
+++ b/examples/todoapp/web/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
 
 // a temporary workaround for a bug in jsRun invocation - see https://youtrack.jetbrains.com/issue/KT-48273
 afterEvaluate {
-    extensions.configure<NodeJsRootExtension> {
+    rootProject.extensions.configure<NodeJsRootExtension> {
         versions.webpackDevServer.version = "4.0.0"
     }
 }

--- a/examples/web-compose-bird/build.gradle.kts
+++ b/examples/web-compose-bird/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 
 // a temporary workaround for a bug in jsRun invocation - see https://youtrack.jetbrains.com/issue/KT-48273
 afterEvaluate {
-    extensions.configure<NodeJsRootExtension> {
+    rootProject.extensions.configure<NodeJsRootExtension> {
         versions.webpackDevServer.version = "4.0.0"
     }
 }

--- a/examples/web-landing/build.gradle.kts
+++ b/examples/web-landing/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
 
 // a temporary workaround for a bug in jsRun invocation - see https://youtrack.jetbrains.com/issue/KT-48273
 afterEvaluate {
-    extensions.configure<NodeJsRootExtension> {
+    rootProject.extensions.configure<NodeJsRootExtension> {
         versions.webpackDevServer.version = "4.0.0"
     }
 }

--- a/examples/web-with-react/build.gradle.kts
+++ b/examples/web-with-react/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 
 // a temporary workaround for a bug in jsRun invocation - see https://youtrack.jetbrains.com/issue/KT-48273
 afterEvaluate {
-    extensions.configure<NodeJsRootExtension> {
+	rootProject.extensions.configure<NodeJsRootExtension> {
         versions.webpackDevServer.version = "4.0.0"
     }
 }


### PR DESCRIPTION
see https://youtrack.jetbrains.com/issue/KT-48273