### PR TITLE
Gradle plugin. macOs. Pass icon and name defined in build.gradle to the Dock

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -315,6 +315,12 @@ private fun JavaExec.configureRunTask(
     executable(javaExecutable(app.javaHomeOrDefault()))
     jvmArgs = arrayListOf<String>().apply {
         addAll(defaultJvmArgs)
+
+        if (currentOS == OS.MacOS) {
+            val file = app.nativeDistributions.macOS.iconFile.ioFileOrNull
+            if (file != null) add("-Xdock:icon=$file")
+        }
+
         addAll(app.jvmArgs)
         val appResourcesDir = prepareAppResources.get().destinationDir
         add("-D$APP_RESOURCES_DIR=${appResourcesDir.absolutePath}")


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1342