### PR TITLE
Create destination dir if it does not exist

### DIFF
--- a/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/DownloadFromSpaceTask.kt
+++ b/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/DownloadFromSpaceTask.kt
@@ -45,7 +45,10 @@ abstract class DownloadFromSpaceMavenRepoTask : DefaultTask() {
         }
 
         val destinationDir = module.localDir
-        if (destinationDir.exists()) {
+
+        if (destinationDir.isFile)
+            error("Destination dir is a file: $destinationDir")
+        else if (destinationDir.exists()) {
             if (module.version.endsWith("-SNAPSHOT")) {
                 destinationDir.deleteRecursively()
             } else {
@@ -65,6 +68,8 @@ abstract class DownloadFromSpaceMavenRepoTask : DefaultTask() {
                     }
                 }
             }
+        } else {
+            destinationDir.mkdirs()
         }
 
         DownloadAction(project, this).apply {

--- a/compose/settings.gradle.kts
+++ b/compose/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
             maven("https://maven.pkg.jetbrains.space/public/p/space/maven")
         }
         dependencies {
-            classpath("org.jetbrains.compose.internal.build-helpers:publishing:0.1.4")
+            classpath("org.jetbrains.compose.internal.build-helpers:publishing:0.1.5")
         }
     }
 }


### PR DESCRIPTION
Otherwise DownloadAction might assume,
that the destination is actually a file,
when just one file is requested
(which is true for some POM only compose modules)