### PR TITLE
web: remove Options for event listeners

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
@@ -95,17 +95,15 @@ fun AttrsBuilder<HTMLFormElement>.target(value: FormTarget) =
     attr("target", value.targetStr)
 
 fun AttrsBuilder<HTMLFormElement>.onSubmit(
-    options: Options = Options.DEFAULT,
     listener: (SyntheticSubmitEvent) -> Unit
 ) {
-    addEventListener(eventName = EventsListenerBuilder.SUBMIT, options = options, listener = listener)
+    addEventListener(eventName = EventsListenerBuilder.SUBMIT, listener = listener)
 }
 
 fun AttrsBuilder<HTMLFormElement>.onReset(
-    options: Options = Options.DEFAULT,
     listener: (SyntheticSubmitEvent) -> Unit
 ) {
-    addEventListener(eventName = EventsListenerBuilder.RESET, options = options, listener = listener)
+    addEventListener(eventName = EventsListenerBuilder.RESET, listener = listener)
 }
 
 /* Input attributes */

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/EventsListenerBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/EventsListenerBuilder.kt
@@ -24,168 +24,168 @@ open class EventsListenerBuilder {
 
     /* Mouse Events */
 
-    fun onContextMenu(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(CONTEXTMENU, options, listener))
+    fun onContextMenu(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(CONTEXTMENU, listener))
     }
 
-    fun onClick(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(CLICK, options, listener))
+    fun onClick(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(CLICK, listener))
     }
 
-    fun onDoubleClick(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(DBLCLICK, options, listener))
+    fun onDoubleClick(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(DBLCLICK, listener))
     }
 
-    fun onMouseDown(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEDOWN, options, listener))
+    fun onMouseDown(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEDOWN, listener))
     }
 
-    fun onMouseUp(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEUP, options, listener))
+    fun onMouseUp(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEUP, listener))
     }
 
-    fun onMouseEnter(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEENTER, options, listener))
+    fun onMouseEnter(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEENTER, listener))
     }
 
-    fun onMouseLeave(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSELEAVE, options, listener))
+    fun onMouseLeave(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSELEAVE, listener))
     }
 
-    fun onMouseMove(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEMOVE, options, listener))
+    fun onMouseMove(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEMOVE, listener))
     }
 
-    fun onMouseOut(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEOUT, options, listener))
+    fun onMouseOut(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEOUT, listener))
     }
 
-    fun onMouseOver(options: Options = Options.DEFAULT, listener: SyntheticMouseEventListener) {
-        listeners.add(MouseEventListener(MOUSEOVER, options, listener))
+    fun onMouseOver(listener: SyntheticMouseEventListener) {
+        listeners.add(MouseEventListener(MOUSEOVER, listener))
     }
 
-    fun onWheel(options: Options = Options.DEFAULT, listener: SyntheticWheelEventListener) {
-        listeners.add(MouseWheelEventListener(WHEEL, options, listener))
+    fun onWheel(listener: SyntheticWheelEventListener) {
+        listeners.add(MouseWheelEventListener(WHEEL, listener))
     }
 
     /* Drag Events */
 
-    fun onDrag(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAG, options, listener))
+    fun onDrag(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAG, listener))
     }
 
-    fun onDrop(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DROP, options, listener))
+    fun onDrop(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DROP, listener))
     }
 
-    fun onDragStart(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAGSTART, options, listener))
+    fun onDragStart(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAGSTART, listener))
     }
 
-    fun onDragEnd(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAGEND, options, listener))
+    fun onDragEnd(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAGEND, listener))
     }
 
-    fun onDragOver(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAGOVER, options, listener))
+    fun onDragOver(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAGOVER, listener))
     }
 
-    fun onDragEnter(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAGENTER, options, listener))
+    fun onDragEnter(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAGENTER, listener))
     }
 
-    fun onDragLeave(options: Options = Options.DEFAULT, listener: SyntheticDragEventListener) {
-        listeners.add(DragEventListener(DRAGLEAVE, options, listener))
+    fun onDragLeave(listener: SyntheticDragEventListener) {
+        listeners.add(DragEventListener(DRAGLEAVE, listener))
     }
 
     /* End of Drag Events */
 
     /* Clipboard Events */
 
-    fun onCopy(options: Options = Options.DEFAULT, listener: (SyntheticClipboardEvent) -> Unit) {
-        listeners.add(ClipboardEventListener(COPY, options, listener))
+    fun onCopy(listener: (SyntheticClipboardEvent) -> Unit) {
+        listeners.add(ClipboardEventListener(COPY, listener))
     }
 
-    fun onCut(options: Options = Options.DEFAULT, listener: (SyntheticClipboardEvent) -> Unit) {
-        listeners.add(ClipboardEventListener(CUT, options, listener))
+    fun onCut(listener: (SyntheticClipboardEvent) -> Unit) {
+        listeners.add(ClipboardEventListener(CUT, listener))
     }
 
-    fun onPaste(options: Options = Options.DEFAULT, listener: (SyntheticClipboardEvent) -> Unit) {
-        listeners.add(ClipboardEventListener(PASTE, options, listener))
+    fun onPaste(listener: (SyntheticClipboardEvent) -> Unit) {
+        listeners.add(ClipboardEventListener(PASTE, listener))
     }
 
     /* End of Clipboard Events */
 
     /* Keyboard Events */
 
-    fun onKeyDown(options: Options = Options.DEFAULT, listener: (SyntheticKeyboardEvent) -> Unit) {
-        listeners.add(KeyboardEventListener(KEYDOWN, options, listener))
+    fun onKeyDown(listener: (SyntheticKeyboardEvent) -> Unit) {
+        listeners.add(KeyboardEventListener(KEYDOWN, listener))
     }
 
-    fun onKeyUp(options: Options = Options.DEFAULT, listener: (SyntheticKeyboardEvent) -> Unit) {
-        listeners.add(KeyboardEventListener(KEYUP, options, listener))
+    fun onKeyUp(listener: (SyntheticKeyboardEvent) -> Unit) {
+        listeners.add(KeyboardEventListener(KEYUP, listener))
     }
 
     /* End of Keyboard Events */
 
     /* Focus Events */
 
-    fun onFocus(options: Options = Options.DEFAULT, listener: (SyntheticFocusEvent) -> Unit) {
-        listeners.add(FocusEventListener(FOCUS, options, listener))
+    fun onFocus(listener: (SyntheticFocusEvent) -> Unit) {
+        listeners.add(FocusEventListener(FOCUS, listener))
     }
 
-    fun onBlur(options: Options = Options.DEFAULT, listener: (SyntheticFocusEvent) -> Unit) {
-        listeners.add(FocusEventListener(BLUR, options, listener))
+    fun onBlur(listener: (SyntheticFocusEvent) -> Unit) {
+        listeners.add(FocusEventListener(BLUR, listener))
     }
 
-    fun onFocusIn(options: Options = Options.DEFAULT, listener: (SyntheticFocusEvent) -> Unit) {
-        listeners.add(FocusEventListener(FOCUSIN, options, listener))
+    fun onFocusIn(listener: (SyntheticFocusEvent) -> Unit) {
+        listeners.add(FocusEventListener(FOCUSIN, listener))
     }
 
-    fun onFocusOut(options: Options = Options.DEFAULT, listener: (SyntheticFocusEvent) -> Unit) {
-        listeners.add(FocusEventListener(FOCUSOUT, options, listener))
+    fun onFocusOut(listener: (SyntheticFocusEvent) -> Unit) {
+        listeners.add(FocusEventListener(FOCUSOUT, listener))
     }
 
     /* End of Focus Events */
 
     /* Touch Events */
 
-    fun onTouchCancel(options: Options = Options.DEFAULT, listener: (SyntheticTouchEvent) -> Unit) {
-        listeners.add(TouchEventListener(TOUCHCANCEL, options, listener))
+    fun onTouchCancel(listener: (SyntheticTouchEvent) -> Unit) {
+        listeners.add(TouchEventListener(TOUCHCANCEL, listener))
     }
 
-    fun onTouchMove(options: Options = Options.DEFAULT, listener: (SyntheticTouchEvent) -> Unit) {
-        listeners.add(TouchEventListener(TOUCHMOVE, options, listener))
+    fun onTouchMove(listener: (SyntheticTouchEvent) -> Unit) {
+        listeners.add(TouchEventListener(TOUCHMOVE, listener))
     }
 
-    fun onTouchEnd(options: Options = Options.DEFAULT, listener: (SyntheticTouchEvent) -> Unit) {
-        listeners.add(TouchEventListener(TOUCHEND, options, listener))
+    fun onTouchEnd(listener: (SyntheticTouchEvent) -> Unit) {
+        listeners.add(TouchEventListener(TOUCHEND, listener))
     }
 
-    fun onTouchStart(options: Options = Options.DEFAULT, listener: (SyntheticTouchEvent) -> Unit) {
-        listeners.add(TouchEventListener(TOUCHSTART, options, listener))
+    fun onTouchStart(listener: (SyntheticTouchEvent) -> Unit) {
+        listeners.add(TouchEventListener(TOUCHSTART, listener))
     }
 
     /* End of Touch Events */
 
     /* Animation Events */
 
-    fun onAnimationEnd(options: Options = Options.DEFAULT, listener: (SyntheticAnimationEvent) -> Unit) {
-        listeners.add(AnimationEventListener(ANIMATIONEND, options, listener))
+    fun onAnimationEnd(listener: (SyntheticAnimationEvent) -> Unit) {
+        listeners.add(AnimationEventListener(ANIMATIONEND, listener))
     }
 
-    fun onAnimationIteration(options: Options = Options.DEFAULT, listener: (SyntheticAnimationEvent) -> Unit) {
-        listeners.add(AnimationEventListener(ANIMATIONITERATION, options, listener))
+    fun onAnimationIteration(listener: (SyntheticAnimationEvent) -> Unit) {
+        listeners.add(AnimationEventListener(ANIMATIONITERATION, listener))
     }
 
-    fun onAnimationStart(options: Options = Options.DEFAULT, listener: (SyntheticAnimationEvent) -> Unit) {
-        listeners.add(AnimationEventListener(ANIMATIONSTART, options, listener))
+    fun onAnimationStart(listener: (SyntheticAnimationEvent) -> Unit) {
+        listeners.add(AnimationEventListener(ANIMATIONSTART, listener))
     }
 
     /* End of Animation Events */
 
-    fun onScroll(options: Options = Options.DEFAULT, listener: (SyntheticEvent<EventTarget>) -> Unit) {
-        listeners.add(SyntheticEventListener(SCROLL, options, listener))
+    fun onScroll(listener: (SyntheticEvent<EventTarget>) -> Unit) {
+        listeners.add(SyntheticEventListener(SCROLL, listener))
     }
 
     internal fun collectListeners(): List<SyntheticEventListener<*>> = listeners
@@ -198,18 +198,16 @@ open class EventsListenerBuilder {
      */
     fun <T : SyntheticEvent<out EventTarget>> addEventListener(
         eventName: String,
-        options: Options = Options.DEFAULT,
         listener: (T) -> Unit
     ) {
-        listeners.add(SyntheticEventListener(eventName, options, listener))
+        listeners.add(SyntheticEventListener(eventName, listener))
     }
 
     fun addEventListener(
         eventName: String,
-        options: Options = Options.DEFAULT,
         listener: (SyntheticEvent<EventTarget>) -> Unit
     ) {
-        listeners.add(SyntheticEventListener(eventName, options, listener))
+        listeners.add(SyntheticEventListener(eventName, listener))
     }
 
     internal fun copyListenersFrom(from: EventsListenerBuilder) {

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/SyntheticEventListener.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/SyntheticEventListener.kt
@@ -19,7 +19,6 @@ import org.w3c.dom.events.*
 @OptIn(ComposeWebInternalApi::class)
 open class SyntheticEventListener<T : SyntheticEvent<*>> internal constructor(
     val event: String,
-    val options: Options,
     val listener: (T) -> Unit
 ) : EventListener, NamedEventListener {
 
@@ -31,20 +30,11 @@ open class SyntheticEventListener<T : SyntheticEvent<*>> internal constructor(
     }
 }
 
-class Options {
-    // TODO: add options for addEventListener
-
-    companion object {
-        val DEFAULT = Options()
-    }
-}
-
 internal class AnimationEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticAnimationEvent) -> Unit
 ) : SyntheticEventListener<SyntheticAnimationEvent>(
-    event, options, listener
+    event, listener
 ) {
     override fun handleEvent(event: Event) {
         listener(SyntheticAnimationEvent(event, event.unsafeCast<AnimationEventDetails>()))
@@ -53,9 +43,8 @@ internal class AnimationEventListener(
 
 internal class MouseEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticMouseEvent) -> Unit
-) : SyntheticEventListener<SyntheticMouseEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticMouseEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticMouseEvent(event.unsafeCast<MouseEvent>()))
     }
@@ -63,9 +52,8 @@ internal class MouseEventListener(
 
 internal class MouseWheelEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticWheelEvent) -> Unit
-) : SyntheticEventListener<SyntheticWheelEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticWheelEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticWheelEvent(event.unsafeCast<WheelEvent>()))
     }
@@ -73,9 +61,8 @@ internal class MouseWheelEventListener(
 
 internal class KeyboardEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticKeyboardEvent) -> Unit
-) : SyntheticEventListener<SyntheticKeyboardEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticKeyboardEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticKeyboardEvent(event.unsafeCast<KeyboardEvent>()))
     }
@@ -83,9 +70,8 @@ internal class KeyboardEventListener(
 
 internal class FocusEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticFocusEvent) -> Unit
-) : SyntheticEventListener<SyntheticFocusEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticFocusEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticFocusEvent(event.unsafeCast<FocusEvent>()))
     }
@@ -93,9 +79,8 @@ internal class FocusEventListener(
 
 internal class TouchEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticTouchEvent) -> Unit
-) : SyntheticEventListener<SyntheticTouchEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticTouchEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticTouchEvent(event.unsafeCast<TouchEvent>()))
     }
@@ -103,9 +88,8 @@ internal class TouchEventListener(
 
 internal class DragEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticDragEvent) -> Unit
-) : SyntheticEventListener<SyntheticDragEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticDragEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticDragEvent(event.unsafeCast<DragEvent>()))
     }
@@ -113,9 +97,8 @@ internal class DragEventListener(
 
 internal class ClipboardEventListener(
     event: String,
-    options: Options,
     listener: (SyntheticClipboardEvent) -> Unit
-) : SyntheticEventListener<SyntheticClipboardEvent>(event, options, listener) {
+) : SyntheticEventListener<SyntheticClipboardEvent>(event, listener) {
     override fun handleEvent(event: Event) {
         listener(SyntheticClipboardEvent(event.unsafeCast<ClipboardEvent>()))
     }
@@ -123,11 +106,10 @@ internal class ClipboardEventListener(
 
 internal class InputEventListener<InputValueType, Target: EventTarget>(
     eventName: String = INPUT,
-    options: Options,
     val inputType: InputType<InputValueType>,
     listener: (SyntheticInputEvent<InputValueType, Target>) -> Unit
 ) : SyntheticEventListener<SyntheticInputEvent<InputValueType, Target>>(
-    eventName, options, listener
+    eventName, listener
 ) {
     override fun handleEvent(event: Event) {
         val value = inputType.inputValue(event)
@@ -136,11 +118,10 @@ internal class InputEventListener<InputValueType, Target: EventTarget>(
 }
 
 internal class ChangeEventListener<InputValueType, Target: EventTarget>(
-    options: Options,
     val inputType: InputType<InputValueType>,
     listener: (SyntheticChangeEvent<InputValueType, Target>) -> Unit
 ) : SyntheticEventListener<SyntheticChangeEvent<InputValueType, Target>>(
-    CHANGE, options, listener
+    CHANGE, listener
 ) {
     override fun handleEvent(event: Event) {
         val value = inputType.inputValue(event)
@@ -149,10 +130,9 @@ internal class ChangeEventListener<InputValueType, Target: EventTarget>(
 }
 
 internal class SelectEventListener<Target: EventTarget>(
-    options: Options,
     listener: (SyntheticSelectEvent<Target>) -> Unit
 ) : SyntheticEventListener<SyntheticSelectEvent<Target>>(
-    SELECT, options, listener
+    SELECT, listener
 ) {
     override fun handleEvent(event: Event) {
         listener(SyntheticSelectEvent(event, event.target.unsafeCast<SelectionInfoDetails>()))

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/InputAttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/InputAttrsBuilder.kt
@@ -69,38 +69,33 @@ class InputAttrsBuilder<ValueType>(
     }
 
     fun onInvalid(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticEvent<HTMLInputElement>) -> Unit
     ) {
-        addEventListener(INVALID, options, listener)
+        addEventListener(INVALID, listener)
     }
 
     fun onInput(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticInputEvent<ValueType, HTMLInputElement>) -> Unit
     ) {
-        listeners.add(InputEventListener(eventName = INPUT, options, inputType, listener))
+        listeners.add(InputEventListener(eventName = INPUT, inputType, listener))
     }
 
     fun onChange(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticChangeEvent<ValueType, HTMLInputElement>) -> Unit
     ) {
-        listeners.add(ChangeEventListener(options, inputType, listener))
+        listeners.add(ChangeEventListener(inputType, listener))
     }
 
     fun onBeforeInput(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticInputEvent<ValueType, HTMLInputElement>) -> Unit
     ) {
-        listeners.add(InputEventListener(eventName = BEFOREINPUT, options, inputType, listener))
+        listeners.add(InputEventListener(eventName = BEFOREINPUT, inputType, listener))
     }
 
     fun onSelect(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticSelectEvent<HTMLInputElement>) -> Unit
     ) {
-        listeners.add(SelectEventListener(options, listener))
+        listeners.add(SelectEventListener(listener))
     }
 }
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/SelectAttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/SelectAttrsBuilder.kt
@@ -8,7 +8,6 @@ package androidx.compose.web.attributes
 import org.jetbrains.compose.web.attributes.AttrsBuilder
 import org.jetbrains.compose.web.attributes.EventsListenerBuilder.Companion.CHANGE
 import org.jetbrains.compose.web.attributes.EventsListenerBuilder.Companion.INPUT
-import org.jetbrains.compose.web.attributes.Options
 import org.jetbrains.compose.web.attributes.SyntheticEventListener
 import org.jetbrains.compose.web.events.SyntheticChangeEvent
 import org.jetbrains.compose.web.events.SyntheticInputEvent
@@ -18,26 +17,23 @@ import org.w3c.dom.events.Event
 class SelectAttrsBuilder : AttrsBuilder<HTMLSelectElement>() {
 
     fun onInput(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticInputEvent<String?, HTMLSelectElement>) -> Unit
     ) {
-        listeners.add(SelectInputEventListener(INPUT, options, listener))
+        listeners.add(SelectInputEventListener(INPUT, listener))
     }
 
     fun onChange(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticChangeEvent<String?, HTMLSelectElement>) -> Unit
     ) {
-        listeners.add(SelectChangeEventListener(options, listener))
+        listeners.add(SelectChangeEventListener(listener))
     }
 }
 
 private class SelectInputEventListener(
     eventName: String = INPUT,
-    options: Options = Options.DEFAULT,
     listener: (SyntheticInputEvent<String?, HTMLSelectElement>) -> Unit
 ) : SyntheticEventListener<SyntheticInputEvent<String?, HTMLSelectElement>>(
-    eventName, options, listener
+    eventName, listener
 ) {
     override fun handleEvent(event: Event) {
         val value = event.target?.asDynamic().value?.toString()
@@ -46,10 +42,9 @@ private class SelectInputEventListener(
 }
 
 private class SelectChangeEventListener(
-    options: Options = Options.DEFAULT,
     listener: (SyntheticChangeEvent<String?, HTMLSelectElement>) -> Unit
 ): SyntheticEventListener<SyntheticChangeEvent<String?, HTMLSelectElement>>(
-    CHANGE, options, listener
+    CHANGE, listener
 ) {
     override fun handleEvent(event: Event) {
         val value = event.target?.asDynamic().value?.toString()

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/TextAreaAttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/builders/TextAreaAttrsBuilder.kt
@@ -24,30 +24,26 @@ class TextAreaAttrsBuilder : AttrsBuilder<HTMLTextAreaElement>() {
     }
 
     fun onInput(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticInputEvent<String, HTMLTextAreaElement>) -> Unit
     ) {
-        listeners.add(InputEventListener(INPUT, options, InputType.Text, listener))
+        listeners.add(InputEventListener(INPUT, InputType.Text, listener))
     }
 
     fun onChange(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticChangeEvent<String, HTMLTextAreaElement>) -> Unit
     ) {
-        listeners.add(ChangeEventListener(options, InputType.Text, listener))
+        listeners.add(ChangeEventListener(InputType.Text, listener))
     }
 
     fun onBeforeInput(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticInputEvent<String, HTMLTextAreaElement>) -> Unit
     ) {
-        listeners.add(InputEventListener(BEFOREINPUT, options, InputType.Text, listener))
+        listeners.add(InputEventListener(BEFOREINPUT, InputType.Text, listener))
     }
 
     fun onSelect(
-        options: Options = Options.DEFAULT,
         listener: (SyntheticSelectEvent<HTMLTextAreaElement>) -> Unit
     ) {
-        listeners.add(SelectEventListener(options, listener))
+        listeners.add(SelectEventListener(listener))
     }
 }


### PR DESCRIPTION
Options were never actually applied and there was no way to use anything beside Options.DEFAULT

We had a discussion about this some time ago. The conclusion was that it's likely redundant parameter for most of the cases.
Anyway It's still possible to set options using k/js `addEventListener` on the element's reference

Here is a related PR that was not merged: https://github.com/JetBrains/compose-jb/pull/860#issuecomment-875685792 