### PR TITLE
web (breaking change): move CSSUnit convertors functions and CSS operations (on units) to their new scopes

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsBuilder.kt
@@ -2,6 +2,8 @@ package org.jetbrains.compose.web.attributes
 
 import androidx.compose.runtime.DisposableEffectResult
 import androidx.compose.runtime.DisposableEffectScope
+import org.jetbrains.compose.web.css.CSSOperationsScope
+import org.jetbrains.compose.web.css.CSSUnitsConversionScope
 import org.jetbrains.compose.web.css.StyleBuilder
 import org.jetbrains.compose.web.css.StyleBuilderImpl
 import org.w3c.dom.Element
@@ -17,7 +19,7 @@ import org.w3c.dom.HTMLElement
  * are extracted to a separate methods.
  *
  */
-open class AttrsBuilder<TElement : Element> : EventsListenerBuilder() {
+open class AttrsBuilder<TElement : Element> : EventsListenerBuilder(), CSSUnitsConversionScope, CSSOperationsScope {
     internal val attributesMap = mutableMapOf<String, String>()
     internal val styleBuilder = StyleBuilderImpl()
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSOperations.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSOperations.kt
@@ -5,16 +5,6 @@
 
 package org.jetbrains.compose.web.css
 
-operator fun <T: CSSUnit> CSSSizeValue<T>.times(num: Number): CSSSizeValue<T> = CSSUnitValueTyped(value * num.toFloat(), unit)
-operator fun <T: CSSUnit> Number.times(unit: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(unit.value * toFloat(), unit.unit)
-
-operator fun <T: CSSUnit> CSSSizeValue<T>.div(num: Number): CSSSizeValue<T> = CSSUnitValueTyped(value / num.toFloat(), unit)
-
-operator fun <T: CSSUnit> CSSSizeValue<T>.plus(b: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(value + b.value, unit)
-operator fun <T: CSSUnit> CSSSizeValue<T>.minus(b: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(value - b.value, unit)
-operator fun <T: CSSUnit> CSSSizeValue<T>.unaryMinus(): CSSSizeValue<T> = CSSUnitValueTyped(-value, unit)
-operator fun <T: CSSUnit> CSSSizeValue<T>.unaryPlus(): CSSSizeValue<T> = CSSUnitValueTyped(value, unit)
-
 external interface CSSCalcOperation<T : CSSUnit>: CSSNumericValue<T>
 
 data class CSSCalcValue<T : CSSUnit>(
@@ -52,20 +42,34 @@ private data class CSSDiv<T : CSSUnit>(
     override fun toString(): String = "($l / $r)"
 }
 
-operator fun <T: CSSUnit> CSSNumericValue<out T>.plus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this, b))
-operator fun <T: CSSUnit> CSSCalcValue<out T>.plus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this.op, b))
-operator fun <T: CSSUnit> CSSNumericValue<out T>.plus(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this, b.op))
+/**
+ * This interface is not supposed to be implemented by any classes
+ */
+interface CSSOperationsScope {
+    operator fun <T: CSSUnit> CSSNumericValue<out T>.plus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this, b))
+    operator fun <T: CSSUnit> CSSCalcValue<out T>.plus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this.op, b))
+    operator fun <T: CSSUnit> CSSNumericValue<out T>.plus(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSPlus(this, b.op))
 
-operator fun <T: CSSUnit> CSSNumericValue<out T>.minus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this, b))
-operator fun <T: CSSUnit> CSSCalcValue<out T>.minus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this.op, b))
-operator fun <T: CSSUnit> CSSNumericValue<out T>.minus(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this, b.op))
+    operator fun <T: CSSUnit> CSSNumericValue<out T>.minus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this, b))
+    operator fun <T: CSSUnit> CSSCalcValue<out T>.minus(b: CSSNumericValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this.op, b))
+    operator fun <T: CSSUnit> CSSNumericValue<out T>.minus(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSMinus(this, b.op))
 
-operator fun <T: CSSUnit> CSSCalcValue<out T>.times(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSTimes(this.op, b))
-operator fun <T: CSSUnit> Number.times(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSTimes(b.op, this, false))
+    operator fun <T: CSSUnit> CSSCalcValue<out T>.times(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSTimes(this.op, b))
+    operator fun <T: CSSUnit> Number.times(b: CSSCalcValue<out T>): CSSCalcValue<T> = CSSCalcValue(CSSTimes(b.op, this, false))
 
-operator fun <T: CSSUnit> CSSNumericValue<T>.div(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSDiv(this, b))
-operator fun <T: CSSUnit> CSSCalcValue<out T>.div(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSDiv(this.op, b))
+    operator fun <T: CSSUnit> CSSNumericValue<T>.div(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSDiv(this, b))
+    operator fun <T: CSSUnit> CSSCalcValue<out T>.div(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSDiv(this.op, b))
 
-operator fun <T: CSSUnit> CSSNumericValue<T>.times(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSTimes(this, b))
-operator fun <T: CSSUnit> Number.times(b: CSSNumericValue<T>): CSSCalcValue<T> = CSSCalcValue(CSSTimes(b, this, false))
+    operator fun <T: CSSUnit> CSSNumericValue<T>.times(b: Number): CSSCalcValue<T> = CSSCalcValue(CSSTimes(this, b))
+    operator fun <T: CSSUnit> Number.times(b: CSSNumericValue<T>): CSSCalcValue<T> = CSSCalcValue(CSSTimes(b, this, false))
 
+    operator fun <T: CSSUnit> CSSSizeValue<T>.times(num: Number): CSSSizeValue<T> = CSSUnitValueTyped(value * num.toFloat(), unit)
+    operator fun <T: CSSUnit> Number.times(unit: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(unit.value * toFloat(), unit.unit)
+
+    operator fun <T: CSSUnit> CSSSizeValue<T>.div(num: Number): CSSSizeValue<T> = CSSUnitValueTyped(value / num.toFloat(), unit)
+
+    operator fun <T: CSSUnit> CSSSizeValue<T>.plus(b: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(value + b.value, unit)
+    operator fun <T: CSSUnit> CSSSizeValue<T>.minus(b: CSSSizeValue<T>): CSSSizeValue<T> = CSSUnitValueTyped(value - b.value, unit)
+    operator fun <T: CSSUnit> CSSSizeValue<T>.unaryMinus(): CSSSizeValue<T> = CSSUnitValueTyped(-value, unit)
+    operator fun <T: CSSUnit> CSSSizeValue<T>.unaryPlus(): CSSSizeValue<T> = CSSUnitValueTyped(value, unit)
+}

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSUnits.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSUnits.kt
@@ -172,78 +172,84 @@ interface CSSUnit {
     }
 }
 
+/**
+ * This interface is not supposed to be implemented by any classes
+ */
+interface CSSUnitsConversionScope {
 
-val Number.number
-    get(): CSSSizeValue<CSSUnit.number> = CSSUnitValueTyped(this.toFloat(), CSSUnit.number)
+    val Number.number
+        get(): CSSSizeValue<CSSUnit.number> = CSSUnitValueTyped(this.toFloat(), CSSUnit.number)
 
-val Number.percent
-    get() : CSSSizeValue<CSSUnit.percent> = CSSUnitValueTyped(this.toFloat(), CSSUnit.percent)
+    val Number.percent
+        get() : CSSSizeValue<CSSUnit.percent> = CSSUnitValueTyped(this.toFloat(), CSSUnit.percent)
 
-val Number.em
-    get() : CSSSizeValue<CSSUnit.em> = CSSUnitValueTyped(this.toFloat(), CSSUnit.em)
+    val Number.em
+        get() : CSSSizeValue<CSSUnit.em> = CSSUnitValueTyped(this.toFloat(), CSSUnit.em)
 
-val Number.ex
-    get(): CSSSizeValue<CSSUnit.ex> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ex)
+    val Number.ex
+        get(): CSSSizeValue<CSSUnit.ex> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ex)
 
-val Number.ch
-    get(): CSSSizeValue<CSSUnit.ch> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ch)
+    val Number.ch
+        get(): CSSSizeValue<CSSUnit.ch> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ch)
 
-val Number.cssRem
-    get(): CSSSizeValue<CSSUnit.rem> = CSSUnitValueTyped(this.toFloat(), CSSUnit.rem)
+    val Number.cssRem
+        get(): CSSSizeValue<CSSUnit.rem> = CSSUnitValueTyped(this.toFloat(), CSSUnit.rem)
 
-val Number.vw
-    get(): CSSSizeValue<CSSUnit.vw> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vw)
+    val Number.vw
+        get(): CSSSizeValue<CSSUnit.vw> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vw)
 
-val Number.vh
-    get(): CSSSizeValue<CSSUnit.vh> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vh)
+    val Number.vh
+        get(): CSSSizeValue<CSSUnit.vh> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vh)
 
-val Number.vmin
-    get(): CSSSizeValue<CSSUnit.vmin> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vmin)
+    val Number.vmin
+        get(): CSSSizeValue<CSSUnit.vmin> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vmin)
 
-val Number.vmax
-    get(): CSSSizeValue<CSSUnit.vmax> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vmax)
+    val Number.vmax
+        get(): CSSSizeValue<CSSUnit.vmax> = CSSUnitValueTyped(this.toFloat(), CSSUnit.vmax)
 
-val Number.cm
-    get(): CSSSizeValue<CSSUnit.cm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.cm)
+    val Number.cm
+        get(): CSSSizeValue<CSSUnit.cm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.cm)
 
-val Number.mm
-    get(): CSSSizeValue<CSSUnit.mm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.mm)
+    val Number.mm
+        get(): CSSSizeValue<CSSUnit.mm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.mm)
 
-val Number.Q
-    get() : CSSSizeValue<CSSUnit.Q> = CSSUnitValueTyped(this.toFloat(), CSSUnit.Q)
+    val Number.Q
+        get() : CSSSizeValue<CSSUnit.Q> = CSSUnitValueTyped(this.toFloat(), CSSUnit.Q)
 
-val Number.pt
-    get(): CSSSizeValue<CSSUnit.pt> = CSSUnitValueTyped(this.toFloat(), CSSUnit.pt)
-val Number.pc
-    get(): CSSSizeValue<CSSUnit.pc> = CSSUnitValueTyped(this.toFloat(), CSSUnit.pc)
-val Number.px
-    get(): CSSSizeValue<CSSUnit.px> = CSSUnitValueTyped(this.toFloat(), CSSUnit.px)
+    val Number.pt
+        get(): CSSSizeValue<CSSUnit.pt> = CSSUnitValueTyped(this.toFloat(), CSSUnit.pt)
+    val Number.pc
+        get(): CSSSizeValue<CSSUnit.pc> = CSSUnitValueTyped(this.toFloat(), CSSUnit.pc)
+    val Number.px
+        get(): CSSSizeValue<CSSUnit.px> = CSSUnitValueTyped(this.toFloat(), CSSUnit.px)
 
-val Number.deg
-    get(): CSSSizeValue<CSSUnit.deg> = CSSUnitValueTyped(this.toFloat(), CSSUnit.deg)
-val Number.grad
-    get(): CSSSizeValue<CSSUnit.grad> = CSSUnitValueTyped(this.toFloat(), CSSUnit.grad)
-val Number.rad
-    get(): CSSSizeValue<CSSUnit.rad> = CSSUnitValueTyped(this.toFloat(), CSSUnit.rad)
-val Number.turn
-    get(): CSSSizeValue<CSSUnit.turn> = CSSUnitValueTyped(this.toFloat(), CSSUnit.turn)
+    val Number.deg
+        get(): CSSSizeValue<CSSUnit.deg> = CSSUnitValueTyped(this.toFloat(), CSSUnit.deg)
+    val Number.grad
+        get(): CSSSizeValue<CSSUnit.grad> = CSSUnitValueTyped(this.toFloat(), CSSUnit.grad)
+    val Number.rad
+        get(): CSSSizeValue<CSSUnit.rad> = CSSUnitValueTyped(this.toFloat(), CSSUnit.rad)
+    val Number.turn
+        get(): CSSSizeValue<CSSUnit.turn> = CSSUnitValueTyped(this.toFloat(), CSSUnit.turn)
 
-val Number.s
-    get(): CSSSizeValue<CSSUnit.s> = CSSUnitValueTyped(this.toFloat(), CSSUnit.s)
-val Number.ms
-    get(): CSSSizeValue<CSSUnit.ms> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ms)
+    val Number.s
+        get(): CSSSizeValue<CSSUnit.s> = CSSUnitValueTyped(this.toFloat(), CSSUnit.s)
+    val Number.ms
+        get(): CSSSizeValue<CSSUnit.ms> = CSSUnitValueTyped(this.toFloat(), CSSUnit.ms)
 
-val Number.Hz
-    get(): CSSSizeValue<CSSUnit.Hz> = CSSUnitValueTyped(this.toFloat(), CSSUnit.Hz)
-val Number.kHz
-    get(): CSSSizeValue<CSSUnit.kHz> = CSSUnitValueTyped(this.toFloat(), CSSUnit.kHz)
+    val Number.Hz
+        get(): CSSSizeValue<CSSUnit.Hz> = CSSUnitValueTyped(this.toFloat(), CSSUnit.Hz)
+    val Number.kHz
+        get(): CSSSizeValue<CSSUnit.kHz> = CSSUnitValueTyped(this.toFloat(), CSSUnit.kHz)
 
-val Number.dpi
-    get(): CSSSizeValue<CSSUnit.dpi> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dpi)
-val Number.dpcm
-    get(): CSSSizeValue<CSSUnit.dpcm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dpcm)
-val Number.dppx
-    get(): CSSSizeValue<CSSUnit.dppx> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dppx)
+    val Number.dpi
+        get(): CSSSizeValue<CSSUnit.dpi> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dpi)
+    val Number.dpcm
+        get(): CSSSizeValue<CSSUnit.dpcm> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dpcm)
+    val Number.dppx
+        get(): CSSSizeValue<CSSUnit.dppx> = CSSUnitValueTyped(this.toFloat(), CSSUnit.dppx)
 
-val Number.fr
-    get(): CSSSizeValue<CSSUnit.fr> = CSSUnitValueTyped(this.toFloat(), CSSUnit.fr)
+    val Number.fr
+        get(): CSSSizeValue<CSSUnit.fr> = CSSUnitValueTyped(this.toFloat(), CSSUnit.fr)
+
+}

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/Color.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/Color.kt
@@ -4,7 +4,7 @@ package org.jetbrains.compose.web.css
 
 external interface CSSColorValue : StylePropertyValue, CSSVariableValueAs<CSSColorValue>
 
-object Color {
+object Color : CSSUnitsConversionScope {
 
     @Deprecated("use org.jetbrains.compose.web.css.rgb", ReplaceWith("rgb(r, g, b)"))
     data class RGB(val r: Number, val g: Number, val b: Number) : CSSColorValue {
@@ -193,6 +193,6 @@ private class HSLA(val h: CSSAngleValue, val s: Number, val l: Number, val a: Nu
 fun rgb(r: Number, g: Number, b: Number): CSSColorValue = RGB(r, g, b)
 fun rgba(r: Number, g: Number, b: Number, a: Number): CSSColorValue = RGBA(r, g, b, a)
 fun hsl(h: CSSAngleValue, s: Number, l: Number): CSSColorValue = HSL(h, s, l)
-fun hsl(h: Number, s: Number, l: Number): CSSColorValue = HSL(h.deg, s, l)
+fun hsl(h: Number, s: Number, l: Number): CSSColorValue = with(Color) { HSL(h.deg, s, l) }
 fun hsla(h: CSSAngleValue, s: Number, l: Number, a: Number): CSSColorValue = HSLA(h, s, l, a)
-fun hsla(h: Number, s: Number, l: Number, a: Number): CSSColorValue = HSLA(h.deg, s, l, a)
+fun hsla(h: Number, s: Number, l: Number, a: Number): CSSColorValue = with(Color) { HSLA(h.deg, s, l, a) }

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
@@ -7,9 +7,7 @@
 
 package org.jetbrains.compose.web.css
 
-import org.jetbrains.compose.web.internal.runtime.DomElementWrapper
 import org.jetbrains.compose.web.internal.runtime.ComposeWebInternalApi
-import org.w3c.dom.css.CSSStyleDeclaration
 import kotlin.properties.ReadOnlyProperty
 
 /**
@@ -18,7 +16,8 @@ import kotlin.properties.ReadOnlyProperty
  * 1. Add inlined css properties to the element (@see [property])
  * 2. Set values to CSS variables (@see [variable])
  */
-interface StyleBuilder {
+@OptIn(ComposeWebInternalApi::class)
+interface StyleBuilder : CSSUnitsConversionScope, CSSOperationsScope {
     /**
      * Adds arbitrary CSS property to the inline style of the element
      * @param propertyName - the name of css property as [per spec](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference)

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheetBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheetBuilder.kt
@@ -10,7 +10,11 @@ interface CSSRulesHolder {
     }
 }
 
-interface GenericStyleSheetBuilder<TBuilder> : CSSRulesHolder {
+interface GenericStyleSheetBuilder<TBuilder> :
+    CSSRulesHolder,
+    CSSUnitsConversionScope,
+    CSSOperationsScope
+{
     fun buildRules(
         rulesBuild: GenericStyleSheetBuilder<TBuilder>.() -> Unit
     ): CSSRuleDeclarationList

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
@@ -10,8 +10,9 @@ import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
+import org.jetbrains.compose.web.css.CSSOperationsScope
+import org.jetbrains.compose.web.css.CSSUnitsConversionScope
 import org.w3c.dom.Element
-import org.w3c.dom.HTMLElement
 
 interface DOMScope<out TElement : Element>
 
@@ -28,7 +29,7 @@ interface DOMScope<out TElement : Element>
  * }
  * ```
  */
-interface ElementScope<out TElement : Element> : DOMScope<TElement> {
+interface ElementScope<out TElement : Element> : DOMScope<TElement>, CSSUnitsConversionScope, CSSOperationsScope {
 
     /**
      * A side effect of composition that must run for any new unique value of [key]

--- a/web/core/src/jsTest/kotlin/CSSUnitApiTests.kt
+++ b/web/core/src/jsTest/kotlin/CSSUnitApiTests.kt
@@ -13,7 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.jetbrains.compose.web.testutils.*
 
-class CSSUnitApiTests {
+class CSSUnitApiTests : CSSUnitsConversionScope, CSSOperationsScope {
     // TODO: Cover CSS.Q, CSS.khz and CSS.hz after we'll get rid from polyfill
 
     @Test

--- a/web/core/src/jsTest/kotlin/MediaQueryTests.kt
+++ b/web/core/src/jsTest/kotlin/MediaQueryTests.kt
@@ -13,7 +13,6 @@ import org.jetbrains.compose.web.css.mediaMaxWidth
 import org.jetbrains.compose.web.css.media
 import org.jetbrains.compose.web.css.mediaMinHeight
 import org.jetbrains.compose.web.css.mediaMinWidth
-import org.jetbrains.compose.web.css.px
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/CodeSnippetSamples.kt
+++ b/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/CodeSnippetSamples.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.remember
 import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.attributes.name
 import org.jetbrains.compose.web.css.padding
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.dom.Code
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.H4

--- a/web/svg/src/jsTest/kotlin/svg/SvgTests.kt
+++ b/web/svg/src/jsTest/kotlin/svg/SvgTests.kt
@@ -7,8 +7,6 @@ package org.jetbrains.compose.web.core.tests.svg
 
 import org.jetbrains.compose.web.ExperimentalComposeWebSvgApi
 import org.jetbrains.compose.web.css.opacity
-import org.jetbrains.compose.web.css.percent
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.svg.*
 import org.jetbrains.compose.web.testutils.*
 import org.w3c.dom.svg.SVGCircleElement

--- a/web/widgets/src/jsMain/kotlin/Modifier.kt
+++ b/web/widgets/src/jsMain/kotlin/Modifier.kt
@@ -5,7 +5,6 @@ import org.jetbrains.compose.common.ui.unit.Dp
 import org.jetbrains.compose.common.core.graphics.Color
 import org.jetbrains.compose.web.css.backgroundColor
 import org.jetbrains.compose.web.css.margin
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.Color.RGB
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.web.attributes.AttrsBuilder

--- a/web/widgets/src/jsMain/kotlin/Styles.kt
+++ b/web/widgets/src/jsMain/kotlin/Styles.kt
@@ -10,7 +10,6 @@ import org.jetbrains.compose.web.css.FlexDirection
 import org.jetbrains.compose.web.css.display
 import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.left
-import org.jetbrains.compose.web.css.px
 
 import org.jetbrains.compose.web.css.StyleSheet
 

--- a/web/widgets/src/jsMain/kotlin/layouts/text.kt
+++ b/web/widgets/src/jsMain/kotlin/layouts/text.kt
@@ -14,8 +14,6 @@ import org.jetbrains.compose.web.css.fontSize
 import org.jetbrains.compose.web.css.Color.RGB
 import org.jetbrains.compose.common.ui.unit.TextUnit
 import org.jetbrains.compose.common.ui.unit.TextUnitType
-import org.jetbrains.compose.web.css.em
-import org.jetbrains.compose.web.css.px
 
 @Composable
 @ExperimentalComposeWebWidgetsApi

--- a/web/widgets/src/jsMain/kotlin/modifiers/border.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/border.kt
@@ -6,7 +6,6 @@ import org.jetbrains.compose.common.core.graphics.Color
 import org.jetbrains.compose.common.ui.Modifier
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.LineStyle
 import org.jetbrains.compose.web.css.border
 import org.jetbrains.compose.web.css.Color.RGB

--- a/web/widgets/src/jsMain/kotlin/modifiers/clip.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/clip.kt
@@ -7,7 +7,6 @@ import org.jetbrains.compose.annotations.webWidgetsDeprecationMessage
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
 import org.jetbrains.compose.web.css.borderRadius
-import org.jetbrains.compose.web.css.percent
 
 @ExperimentalComposeWebWidgetsApi
 @Deprecated(message = webWidgetsDeprecationMessage)

--- a/web/widgets/src/jsMain/kotlin/modifiers/fillMaxHeight.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/fillMaxHeight.kt
@@ -5,7 +5,6 @@ import org.jetbrains.compose.common.ui.Modifier
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
 import org.jetbrains.compose.web.css.height
-import org.jetbrains.compose.web.css.percent
 
 @ExperimentalComposeWebWidgetsApi
 @Deprecated(message = webWidgetsDeprecationMessage)

--- a/web/widgets/src/jsMain/kotlin/modifiers/fillMaxWidth.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/fillMaxWidth.kt
@@ -5,7 +5,6 @@ import org.jetbrains.compose.common.ui.Modifier
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
 import org.jetbrains.compose.web.css.width
-import org.jetbrains.compose.web.css.percent
 
 @ExperimentalComposeWebWidgetsApi
 @Deprecated(message = webWidgetsDeprecationMessage)

--- a/web/widgets/src/jsMain/kotlin/modifiers/offset.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/offset.kt
@@ -7,7 +7,6 @@ import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
 import org.jetbrains.compose.web.css.marginTop
 import org.jetbrains.compose.web.css.marginLeft
-import org.jetbrains.compose.web.css.px
 
 @ExperimentalComposeWebWidgetsApi
 @Deprecated(message = webWidgetsDeprecationMessage)

--- a/web/widgets/src/jsMain/kotlin/modifiers/size.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/size.kt
@@ -4,7 +4,6 @@ import org.jetbrains.compose.annotations.webWidgetsDeprecationMessage
 import org.jetbrains.compose.common.ui.unit.Dp
 import org.jetbrains.compose.web.css.width
 import org.jetbrains.compose.web.css.height
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.common.internal.castOrCreate
 
 @ExperimentalComposeWebWidgetsApi

--- a/web/widgets/src/jsMain/kotlin/modifiers/width.kt
+++ b/web/widgets/src/jsMain/kotlin/modifiers/width.kt
@@ -5,7 +5,6 @@ import org.jetbrains.compose.common.ui.unit.Dp
 import org.jetbrains.compose.common.ui.Modifier
 import org.jetbrains.compose.common.internal.castOrCreate
 import org.jetbrains.compose.common.ui.ExperimentalComposeWebWidgetsApi
-import org.jetbrains.compose.web.css.px
 import org.jetbrains.compose.web.css.width
 
 @ExperimentalComposeWebWidgetsApi


### PR DESCRIPTION


The intention is to avoid having these functions on top level. They are usually used within specific scopes, so it makes sense to limit the number of places where it's possible to call them.