### PR TITLE
web (breaking change): move `combine` and `feature` functions to GenericStyleSheetBuilder scope (in CSSMediaRule.kt)

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSMediaRule.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/CSSMediaRule.kt
@@ -97,7 +97,7 @@ inline fun <TBuilder> GenericStyleSheetBuilder<TBuilder>.media(
     media(feature(name, value), rulesBuild)
 }
 
-fun feature(
+fun <TBuilder> GenericStyleSheetBuilder<TBuilder>.feature(
     name: String,
     value: StylePropertyValue? = null
 ) = CSSMediaQuery.MediaFeature(name, value)
@@ -110,7 +110,7 @@ inline fun <TBuilder> GenericStyleSheetBuilder<TBuilder>.media(
     media(combine(*mediaList), rulesBuild)
 }
 
-fun combine(
+fun <TBuilder> GenericStyleSheetBuilder<TBuilder>.combine(
     vararg mediaList: CSSMediaQuery
 ) = CSSMediaQuery.Combine(mediaList.toMutableList())
 


### PR DESCRIPTION

these two functions were on topLevel. Changed to extension functions on `GenericStyleSheetBuilder` scope (now it's consistent with the other functions for building `CSSMediaQuery.MediaFeature` in this file