### PR TITLE
Plugin path resolution customization

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -1,7 +1,6 @@
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
-val COMPOSE_CORE_VERSION: String by project
 val COMPOSE_WEB_VERSION: String by project
 val COMPOSE_REPO_USERNAME: String? by project
 val COMPOSE_REPO_KEY: String? by project

--- a/web/settings.gradle.kts
+++ b/web/settings.gradle.kts
@@ -1,23 +1,49 @@
 
 pluginManagement {
     val COMPOSE_CORE_VERSION: String by settings
+    println("[build] compose core version: $COMPOSE_CORE_VERSION")
+
+    // pluginManagement section won't see outer scope, hence the FQ names
+    fun properties(path: String): java.util.Properties? {
+        val localPropertiesFile = File(path)
+        if (!localPropertiesFile.exists()) {
+            return null
+        }
+        return java.io.FileInputStream(localPropertiesFile).use() { inputStream ->
+            val props = java.util.Properties()
+            props.load(inputStream)
+            props
+        }
+    }
+
+    val localProperties: java.util.Properties? = properties("local.properties")
+    
+
+    val repos = (localProperties?.getProperty("compose.web.repos"))?.split(File.pathSeparator)
+
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        mavenLocal()
+
+        repos?.forEach { urlPath ->
+            maven {
+                url = uri(urlPath)
+            }
+        }
+
         maven {
             url = uri("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         }
         maven {
             url = uri("https://packages.jetbrains.team/maven/p/ui/dev")
         }
+
         google()
     }
 
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.compose") {
-                println("[build] compose core version: $COMPOSE_CORE_VERSION")
                 useModule("org.jetbrains.compose:org.jetbrains.compose.gradle.plugin:$COMPOSE_CORE_VERSION")
             } else if (requested.id.id == "org.jetbrains.kotlin.multiplatform") {
                 useModule("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.5.31")

--- a/web/settings.gradle.kts
+++ b/web/settings.gradle.kts
@@ -1,4 +1,6 @@
+
 pluginManagement {
+    val COMPOSE_CORE_VERSION: String by settings
     repositories {
         gradlePluginPortal()
         mavenCentral()
@@ -15,8 +17,8 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.jetbrains.compose") {
-                println("[build] compose core version: ${extra["COMPOSE_CORE_VERSION"]}")
-                useModule("org.jetbrains.compose:org.jetbrains.compose.gradle.plugin:${extra["COMPOSE_CORE_VERSION"]}")
+                println("[build] compose core version: $COMPOSE_CORE_VERSION")
+                useModule("org.jetbrains.compose:org.jetbrains.compose.gradle.plugin:$COMPOSE_CORE_VERSION")
             } else if (requested.id.id == "org.jetbrains.kotlin.multiplatform") {
                 useModule("org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.5.31")
             }


### PR DESCRIPTION
The goal of following commit is to be able to read a list of local maven locations for plugin resolution. For example, if one needs to look for plugin location in common maven folder and  in, say, `/androidx-main/out/.gradle/.m2/repository`, this can be achieved by putting following code to the local.properties:

```
compose.web.repos = /home/shagen/.m2/repository/:/androidx-main/out/.gradle/.m2/repository
```