### PR TITLE
Add option to set macOS build version

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -20,8 +20,11 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     var packageName: String? = null
     var dockName: String? = null
     var setDockNameSameAsPackageName: Boolean = true
+    var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
+    var dmgPackageBuildVersion: String? = null
     var pkgPackageVersion: String? = null
+    var pkgPackageBuildVersion: String? = null
 
     /**
      * An application's unique identifier across Apple's ecosystem.

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -296,6 +296,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                     else
                         provider { mac.dockName }
                 )
+                packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
                 macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })
                 nonValidatedMacSigningSettings = app.nativeDistributions.macOS.signing

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/packageVersions.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/packageVersions.kt
@@ -43,3 +43,31 @@ private fun NativeDistributions.packageVersionFor(
         ?: osSpecificVersion
         ?: packageVersion
 }
+
+internal fun packageBuildVersionFor(
+    project: Project,
+    app: Application,
+    targetFormat: TargetFormat
+): Provider<String?> =
+    project.provider {
+        app.nativeDistributions.packageBuildVersionFor(targetFormat)
+            // fallback to normal version
+            ?: app.nativeDistributions.packageVersionFor(targetFormat)
+            ?: project.version.toString().takeIf { it != "unspecified" }
+            ?: "1.0.0"
+    }
+
+private fun NativeDistributions.packageBuildVersionFor(
+    targetFormat: TargetFormat
+): String? {
+    check(targetFormat.targetOS == OS.MacOS)
+    val formatSpecificVersion: String? = when (targetFormat) {
+        TargetFormat.AppImage -> null
+        TargetFormat.Dmg -> macOS.dmgPackageBuildVersion
+        TargetFormat.Pkg -> macOS.pkgPackageBuildVersion
+        else -> error("invalid target format: $targetFormat")
+    }
+    val osSpecificVersion: String? = macOS.packageBuildVersion
+    return formatSpecificVersion
+        ?: osSpecificVersion
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -129,6 +129,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val packageBuildVersion: Property<String?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val winConsole: Property<Boolean?> = objects.nullableProperty()
 
     @get:Input
@@ -477,7 +481,8 @@ abstract class AbstractJPackageTask @Inject constructor(
         val packageVersion = packageVersion.get()!!
         plist[PlistKeys.CFBundleShortVersionString] = packageVersion
         plist[PlistKeys.LSApplicationCategoryType] = "Unknown"
-        plist[PlistKeys.CFBundleVersion] = packageVersion
+        val packageBuildVersion = packageBuildVersion.get()!!
+        plist[PlistKeys.CFBundleVersion] = packageBuildVersion
         val year = Calendar.getInstance().get(Calendar.YEAR)
         plist[PlistKeys.NSHumanReadableCopyright] = packageCopyright.orNull
             ?: "Copyright (C) $year"

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -481,7 +481,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         val packageVersion = packageVersion.get()!!
         plist[PlistKeys.CFBundleShortVersionString] = packageVersion
         plist[PlistKeys.LSApplicationCategoryType] = "Unknown"
-        val packageBuildVersion = packageBuildVersion.get()!!
+        val packageBuildVersion = packageBuildVersion.orNull ?: packageVersion
         plist[PlistKeys.CFBundleVersion] = packageBuildVersion
         val year = Calendar.getInstance().get(Calendar.YEAR)
         plist[PlistKeys.NSHumanReadableCopyright] = packageCopyright.orNull

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -443,6 +443,12 @@ The following platform-specific options are available
       (see the section `Specifying package version` for details);
     * `pkgPackageVersion = "PKG_VERSION"` — a pkg-specific package version
       (see the section `Specifying package version` for details);
+    * `packageBuildVersion = "DMG_VERSION"` — a package build version
+      (see the section `Specifying package version` for details);
+    * `dmgPackageBuildVersion = "DMG_VERSION"` — a dmg-specific package build version
+      (see the section `Specifying package version` for details);
+    * `pkgPackageBuildVersion = "PKG_VERSION"` — a pkg-specific package build version
+      (see the section `Specifying package version` for details);
     * `infoPlist` — see the section `Customizing Info.plist on macOS` for details;
 * Windows:
     * `console = true` adds a console launcher for the application;

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -130,6 +130,15 @@ You can use the following DSL properties (in order of descending priority):
 * `nativeDistributions.<os>.packageVersion` specifies a version for a single target OS;
 * `nativeDistributions.packageVersion` specifies a version for all packages;
 
+For macOS you can also specify the build version using the following DSL properties (in order of descending priority):
+* `nativeDistributions.macOS.<packageFormat>PackageBuildVersion` specifies a build version for a single package format;
+* `nativeDistributions.macOS.packageBuildVersion` specifies a build version for all macOS packages;
+
+If the build version is not specified, the package version is used.
+See [CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleshortversionstring) (package version)
+and [CFBundleVersion](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) (build version)
+for more information about versions on macOS.
+
 ``` kotlin
 compose.desktop {
     application {
@@ -141,32 +150,32 @@ compose.desktop {
               // a version for all Linux distributables
               packageVersion = "..." 
               // a version only for the deb package
-              debVersion = "..." 
+              debPackageVersion = "..." 
               // a version only for the rpm package
-              rpmVersion = "..." 
+              rpmPackageVersion = "..." 
             }
             macOS {
               // a version for all macOS distributables
               packageVersion = "..."
               // a version only for the dmg package
-              dmgVersion = "..." 
+              dmgPackageVersion = "..." 
               // a version only for the pkg package
-              pkgVersion = "..." 
+              pkgPackageVersion = "..." 
               
               // a build version for all macOS distributables
               packageBuildVersion = "..."
               // a build version only for the dmg package
-              dmgBuildVersion = "..." 
+              dmgPackageBuildVersion = "..." 
               // a build version only for the pkg package
-              pkgBuildVersion = "..." 
+              pkgPackageBuildVersion = "..." 
             }
             windows {
               // a version for all Windows distributables
               packageVersion = "..."  
               // a version only for the msi package
-              msiVersion = "..."
+              msiPackageVersion = "..."
               // a version only for the exe package
-              exeVersion = "..." 
+              exePackageVersion = "..." 
             }
         }
     }

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -152,6 +152,13 @@ compose.desktop {
               dmgVersion = "..." 
               // a version only for the pkg package
               pkgVersion = "..." 
+              
+              // a build version for all macOS distributables
+              packageBuildVersion = "..."
+              // a build version only for the dmg package
+              dmgBuildVersion = "..." 
+              // a build version only for the pkg package
+              pkgBuildVersion = "..." 
             }
             windows {
               // a version for all Windows distributables


### PR DESCRIPTION
Fixes #1611

Currently, the build version is set to the same version as the `packageVersion` property. This PR adds a new option, called `packageBuildVersion` which can be used to customise the build version. If this option is not specified, it will fallback to `packageVersion` for backwards compatibility.
