### PR TITLE
Apple App Store

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -20,6 +20,7 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     var packageName: String? = null
     var dockName: String? = null
     var setDockNameSameAsPackageName: Boolean = true
+    var appStore: Boolean = false
     var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -22,6 +22,7 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     var setDockNameSameAsPackageName: Boolean = true
     var appStore: Boolean = false
     var appCategory: String? = null
+    var entitlementsFile: RegularFileProperty = objects.fileProperty()
     var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -21,6 +21,7 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     var dockName: String? = null
     var setDockNameSameAsPackageName: Boolean = true
     var appStore: Boolean = false
+    var appCategory: String? = null
     var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -47,6 +47,8 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
         fn.execute(notarization)
     }
 
+    val provisioningProfile: RegularFileProperty = objects.fileProperty()
+
     internal val infoPlistSettings = InfoPlistSettings()
     fun infoPlist(fn: Action<InfoPlistSettings>) {
         fn.execute(infoPlistSettings)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -296,6 +296,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                     else
                         provider { mac.dockName }
                 )
+                macAppStore.set(mac.appStore)
                 packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
                 macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -298,6 +298,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                 )
                 macAppStore.set(mac.appStore)
                 macAppCategory.set(mac.appCategory)
+                macEntitlementsFile.set(mac.entitlementsFile)
                 packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
                 macProvisioningProfile.set(mac.provisioningProfile)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -300,6 +300,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                 macAppCategory.set(mac.appCategory)
                 packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
+                macProvisioningProfile.set(mac.provisioningProfile)
                 macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })
                 nonValidatedMacSigningSettings = app.nativeDistributions.macOS.signing
                 iconFile.set(mac.iconFile.orElse(DefaultIcons.forMac(project)))

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -297,6 +297,7 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                         provider { mac.dockName }
                 )
                 macAppStore.set(mac.appStore)
+                macAppCategory.set(mac.appCategory)
                 packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
                 macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
@@ -18,6 +18,7 @@ internal data class ValidatedMacOSSigningSettings(
     val identity: String,
     val keychain: File?,
     val prefix: String,
+    private val appStore: Boolean
 ) {
     val fullDeveloperID: String
         get() {
@@ -26,14 +27,15 @@ internal data class ValidatedMacOSSigningSettings(
             return when {
                 identity.startsWith(developerIdPrefix) -> identity
                 identity.startsWith(thirdPartyMacDeveloperPrefix) -> identity
-                else -> developerIdPrefix + identity
+                else -> (if (!appStore) developerIdPrefix else thirdPartyMacDeveloperPrefix) + identity
             }
         }
 }
 
 internal fun MacOSSigningSettings.validate(
     bundleIDProvider: Provider<String?>,
-    project: Project
+    project: Project,
+    appStoreProvider: Provider<Boolean?>
 ): ValidatedMacOSSigningSettings {
     check(currentOS == OS.MacOS) { ERR_WRONG_OS }
 
@@ -52,12 +54,14 @@ internal fun MacOSSigningSettings.validate(
         }
         keychainFile
     } else null
+    val appStore = appStoreProvider.get()!!
 
     return ValidatedMacOSSigningSettings(
         bundleID = bundleID,
         identity = signIdentity,
         keychain = keychainFile,
-        prefix = signPrefix
+        prefix = signPrefix,
+        appStore = appStore
     )
 }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/validation/ValidatedMacOSSigningSettings.kt
@@ -54,7 +54,7 @@ internal fun MacOSSigningSettings.validate(
         }
         keychainFile
     } else null
-    val appStore = appStoreProvider.get()!!
+    val appStore = appStoreProvider.orNull == true
 
     return ValidatedMacOSSigningSettings(
         bundleID = bundleID,

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -135,6 +135,11 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Optional
     val macAppCategory: Property<String?> = objects.nullableProperty()
 
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    val macEntitlementsFile: RegularFileProperty = objects.fileProperty()
+
     @get:Input
     @get:Optional
     val packageBuildVersion: Property<String?> = objects.nullableProperty()
@@ -344,6 +349,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                 cliArg("--mac-package-identifier", nonValidatedMacBundleID)
                 cliArg("--mac-app-store", macAppStore)
                 cliArg("--mac-app-category", macAppCategory)
+                cliArg("--mac-entitlements", macEntitlementsFile)
 
                 macSigner?.let { signer ->
                     cliArg("--mac-sign", true)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -508,7 +508,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         val packageVersion = packageVersion.get()!!
         plist[PlistKeys.CFBundleShortVersionString] = packageVersion
         // If building for the App Store, use "utilities" as default just like jpackage.
-        val category = macAppCategory.orNull ?: (if (macAppStore.get()!!) "utilities" else null)
+        val category = macAppCategory.orNull ?: (if (macAppStore.orNull == true) "utilities" else null)
         plist[PlistKeys.LSApplicationCategoryType] = category?.let { "public.app-category.$it" } ?: "Unknown"
         val packageBuildVersion = packageBuildVersion.orNull ?: packageVersion
         plist[PlistKeys.CFBundleVersion] = packageBuildVersion

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -284,7 +284,7 @@ abstract class AbstractJPackageTask @Inject constructor(
 
         if (targetFormat != TargetFormat.AppImage) {
             // Args, that can only be used, when creating an installer
-            cliArg("--app-image", appImage)
+            cliArg("--app-image", appImage.dir("${packageName.get()}.app"))
             cliArg("--install-dir", installationPath)
             cliArg("--license-file", licenseFile)
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -441,7 +441,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                 .also { setInfoPlistValues(it) }
                 .writeToFile(jpackageResources.ioFile.resolve("Info.plist"))
 
-            if (macAppStore.get()!!) {
+            if (macAppStore.orNull == true) {
                 val productDefPlistXml = """
                     <key>os</key>
                     <array>

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -291,6 +291,7 @@ abstract class AbstractJPackageTask @Inject constructor(
             cliArg("--app-image", appImage.dir("${packageName.get()}.app"))
             cliArg("--install-dir", installationPath)
             cliArg("--license-file", licenseFile)
+            cliArg("--resource-dir", jpackageResources)
 
             when (currentOS) {
                 OS.Linux -> {
@@ -434,6 +435,17 @@ abstract class AbstractJPackageTask @Inject constructor(
             InfoPlistBuilder(macExtraPlistKeysRawXml.orNull)
                 .also { setInfoPlistValues(it) }
                 .writeToFile(jpackageResources.ioFile.resolve("Info.plist"))
+
+            if (macAppStore.get()!!) {
+                val productDefPlistXml = """
+                    <key>os</key>
+                    <array>
+                        <string>10.13</string>
+                    </array>
+                """.trimIndent()
+                InfoPlistBuilder(productDefPlistXml)
+                    .writeToFile(jpackageResources.ioFile.resolve("product-def.plist"))
+            }
         }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -133,6 +133,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val macAppCategory: Property<String?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val packageBuildVersion: Property<String?> = objects.nullableProperty()
 
     @get:Input
@@ -325,6 +329,7 @@ abstract class AbstractJPackageTask @Inject constructor(
                 cliArg("--mac-package-name", macPackageName)
                 cliArg("--mac-package-identifier", nonValidatedMacBundleID)
                 cliArg("--mac-app-store", macAppStore)
+                cliArg("--mac-app-category", macAppCategory)
 
                 macSigner?.let { signer ->
                     cliArg("--mac-sign", true)
@@ -485,7 +490,9 @@ abstract class AbstractJPackageTask @Inject constructor(
         plist[PlistKeys.CFBundlePackageType] = "APPL"
         val packageVersion = packageVersion.get()!!
         plist[PlistKeys.CFBundleShortVersionString] = packageVersion
-        plist[PlistKeys.LSApplicationCategoryType] = "Unknown"
+        // If building for the App Store, use "utilities" as default just like jpackage.
+        val category = macAppCategory.orNull ?: (if (macAppStore.get()!!) "utilities" else null)
+        plist[PlistKeys.LSApplicationCategoryType] = category?.let { "public.app-category.$it" } ?: "Unknown"
         val packageBuildVersion = packageBuildVersion.orNull ?: packageVersion
         plist[PlistKeys.CFBundleVersion] = packageBuildVersion
         val year = Calendar.getInstance().get(Calendar.YEAR)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -139,6 +139,11 @@ abstract class AbstractJPackageTask @Inject constructor(
     @get:Optional
     val packageBuildVersion: Property<String?> = objects.nullableProperty()
 
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.ABSOLUTE)
+    val macProvisioningProfile: RegularFileProperty = objects.fileProperty()
+
     @get:Input
     @get:Optional
     val winConsole: Property<Boolean?> = objects.nullableProperty()
@@ -282,6 +287,9 @@ abstract class AbstractJPackageTask @Inject constructor(
             if (currentOS == OS.MacOS) {
                 macDockName.orNull?.let { dockName ->
                     javaOption("-Xdock:name=$dockName")
+                }
+                macProvisioningProfile.orNull?.let { provisioningProfile ->
+                    cliArg("--app-content", provisioningProfile)
                 }
             }
         }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -129,6 +129,10 @@ abstract class AbstractJPackageTask @Inject constructor(
 
     @get:Input
     @get:Optional
+    val macAppStore: Property<Boolean?> = objects.nullableProperty()
+
+    @get:Input
+    @get:Optional
     val packageBuildVersion: Property<String?> = objects.nullableProperty()
 
     @get:Input
@@ -183,7 +187,7 @@ abstract class AbstractJPackageTask @Inject constructor(
         val nonValidatedSettings = nonValidatedMacSigningSettings
         if (currentOS == OS.MacOS && nonValidatedSettings?.sign?.get() == true) {
             val validatedSettings =
-                nonValidatedSettings.validate(nonValidatedMacBundleID, project)
+                nonValidatedSettings.validate(nonValidatedMacBundleID, project, macAppStore)
             MacSigner(validatedSettings, runExternalTool)
         } else null
     }
@@ -320,6 +324,7 @@ abstract class AbstractJPackageTask @Inject constructor(
             OS.MacOS -> {
                 cliArg("--mac-package-name", macPackageName)
                 cliArg("--mac-package-identifier", nonValidatedMacBundleID)
+                cliArg("--mac-app-store", macAppStore)
 
                 macSigner?.let { signer ->
                     cliArg("--mac-sign", true)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractJPackageTask.kt
@@ -288,7 +288,12 @@ abstract class AbstractJPackageTask @Inject constructor(
 
         if (targetFormat != TargetFormat.AppImage) {
             // Args, that can only be used, when creating an installer
-            cliArg("--app-image", appImage.dir("${packageName.get()}.app"))
+            if (currentOS == OS.MacOS && macAppStore.orNull == true) {
+                // This is needed to prevent a directory does not exist error.
+                cliArg("--app-image", appImage.dir("${packageName.get()}.app"))
+            } else {
+                cliArg("--app-image", appImage)
+            }
             cliArg("--install-dir", installationPath)
             cliArg("--license-file", licenseFile)
             cliArg("--resource-dir", jpackageResources)

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -439,6 +439,7 @@ The following platform-specific options are available
     * `signing` and `notarization` — see
       [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
       for details;
+    * `appStore = true` — build and sign for the Apple App Store. Requires at least JDK 17;
     * `dmgPackageVersion = "DMG_VERSION"` — a dmg-specific package version
       (see the section `Specifying package version` for details);
     * `pkgPackageVersion = "PKG_VERSION"` — a pkg-specific package version

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -440,6 +440,9 @@ The following platform-specific options are available
       [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
       for details;
     * `appStore = true` — build and sign for the Apple App Store. Requires at least JDK 17;
+    * `appCategory` — category of the app for the Apple App Store. 
+      Default value is `utilities` when building for the App Store, `Unknown` otherwise. 
+      See [LSApplicationCategoryType](https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype) for a list of valid categories;
     * `dmgPackageVersion = "DMG_VERSION"` — a dmg-specific package version
       (see the section `Specifying package version` for details);
     * `pkgPackageVersion = "PKG_VERSION"` — a pkg-specific package version

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -443,6 +443,9 @@ The following platform-specific options are available
     * `appCategory` — category of the app for the Apple App Store. 
       Default value is `utilities` when building for the App Store, `Unknown` otherwise. 
       See [LSApplicationCategoryType](https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype) for a list of valid categories;
+    * `entitlementsFile.set(File("PATH_TO_ENTITLEMENTS"))` — a path to file containing entitlements to use when signing.
+      When a custom file is provided, make sure to add the entitlements that are required for Java apps.
+      See [sandbox.plist](https://github.com/openjdk/jdk/blob/master/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/sandbox.plist) for the default file that is used when building for the App Store. It can be different depending on your JDK version.
     * `dmgPackageVersion = "DMG_VERSION"` — a dmg-specific package version
       (see the section `Specifying package version` for details);
     * `pkgPackageVersion = "PKG_VERSION"` — a pkg-specific package version

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -256,7 +256,7 @@ The following properties are available in the `nativeDistributions` DSL block:
 * `version` — application's version (default value: Gradle project's [version](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getVersion--));
 * `description` — application's description (default value: none);
 * `copyright` — application's copyright (default value: none);
-* `vendor` — application's vendor (default value: none).
+* `vendor` — application's vendor (default value: none);
 * `licenseFile` — application's license (default value: none).
 
 ``` kotlin
@@ -436,7 +436,7 @@ The following platform-specific options are available
     * `packageName` — a name of the application;
     * `dockName` — a name of the application displayed in the menu bar, the "About <App>" menu item, in the dock, etc. 
       Equals to `packageName` by default.
-    * `signing` and `notarization` — see
+    * `signing`, `notarization`, and `provisioningProfile` — see
       [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
       for details;
     * `appStore = true` — build and sign for the Apple App Store. Requires at least JDK 17;

--- a/tutorials/Signing_and_notarization_on_macOS/README.md
+++ b/tutorials/Signing_and_notarization_on_macOS/README.md
@@ -76,6 +76,24 @@ Open [the page](https://developer.apple.com/account/resources/identifiers/list) 
       uniquely identifies an application in Apple's ecosystem.
     * You can use an explicit bundle ID a wildcard, matching multiple bundle IDs.
     * It is recommended to use the reverse DNS notation (e.g.`com.yoursitename.yourappname`).
+
+## Preparing a Provisioning Profile
+For testing on TestFlight (when publishing to the App Store), you need to add a provisioning
+profile. You can skip this step otherwise.
+
+#### Checking existing provisioning profiles
+
+Open https://developer.apple.com/account/resources/profiles/list
+
+#### Creating a new provisioning profile
+
+1. Open [the page](https://developer.apple.com/account/resources/profiles/add) on Apple's developer portal.
+2. Choose `Mac App Store` option under `Distribution`.
+3. Select Profile Type `Mac`.
+4. Select the App ID which you created earlier.
+5. Select the Mac App Distribution certificate you created earlier.
+6. Enter a name.
+7. Click generate and download the provisioning profile.
    
 ## Creating an app-specific password
 
@@ -226,6 +244,21 @@ macOS {
 ```
 xcrun altool --list-providers -u <Apple ID> -p <Notarization password>"
 ```
+
+### Configuring provisioning profile
+
+For testing on TestFlight (when publishing to the App Store), you need to add a provisioning
+profile. You can skip this step otherwise.
+
+Note that this option requires JDK 18 due to [this issue](https://bugs.openjdk.java.net/browse/JDK-8274346).
+
+``` kotlin
+macOS {
+    provisioningProfile.set(project.file("embedded.provisionprofile"))
+}
+```
+
+Make sure to rename your provisioning profile you created earlier to `embedded.provisionprofile`.
 
 ## Using Gradle
 

--- a/tutorials/Signing_and_notarization_on_macOS/README.md
+++ b/tutorials/Signing_and_notarization_on_macOS/README.md
@@ -175,7 +175,7 @@ uniquely identifies an application in Apple's ecosystem.
 macOS {
     signing { 
          sign.set(true)
-         identity.set("John Doe (123)")
+         identity.set("John Doe")
          // keychain.set("/path/to/keychain") 
     }
 }
@@ -183,7 +183,7 @@ macOS {
 
 * Set the `sign` DSL property or  to `true`.
     * Alternatively, the `compose.desktop.mac.sign` Gradle property can be used.
-* Set the `identity` DSL property to the certificate's name, e.g. `"John Doe (123)"`.
+* Set the `identity` DSL property to the certificate's name, e.g. `"John Doe"`.
     *  Alternatively,  the `compose.desktop.mac.signing.identity` Gradle property can be  used.
 * Optionally, set the `keychain` DSL property to the path to the specific keychain, containing your certificate.
     * Alternatively, the `compose.desktop.mac.signing.keychain` Gradle property can be used.

--- a/tutorials/Signing_and_notarization_on_macOS/README.md
+++ b/tutorials/Signing_and_notarization_on_macOS/README.md
@@ -1,7 +1,7 @@
 # Signing and notarizing distributions for macOS
 
 Apple [requires](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution) 
-all 3rd apps to be signed and notarized (checked by Apple) 
+all 3rd party apps to be signed and notarized (checked by Apple) 
 for running on recent versions of macOS. 
 
 ## What is covered
@@ -34,7 +34,10 @@ Open https://developer.apple.com/account/resources/certificates
     * Check `Save to disk` option.
 2. Create and install a new certificate using your [Apple Developer account](https://developer.apple.com/account/):
     * Open https://developer.apple.com/account/resources/certificates/add
-    * Choose the `Developer ID Application` certificate type.
+    * For publishing outside the App Store, choose the `Developer ID Application` certificate type.
+      For publishing on the App Store, you need two certificates. First select the `Mac App Distribution`
+      certificate type, and once you have completed the steps in this section, repeat them again for
+      the `Mac Installer Distribution` certificate type.
     * Upload your Certificate Signing Request from the previous step.
     * Download and install the certificate (drag & drop the certificate into the `Keychain Access` application).
 
@@ -44,8 +47,13 @@ You can find all installed certificates and their keychains by running the follo
 ```
 /usr/bin/security find-certificate -c "Developer ID Application"
 ```
+or the following commands when publishing on the App Store:
+```
+/usr/bin/security find-certificate -c "3rd Party Mac Developer Application"
+/usr/bin/security find-certificate -c "3rd Party Mac Developer Installer"
+```
 
-If you have multiple `Developer ID Application` certificates installed,
+If you have multiple developer certificates of the same type installed,
 you will need to specify the path to the keychain, containing
 the certificate intended for signing.
 
@@ -167,7 +175,7 @@ uniquely identifies an application in Apple's ecosystem.
 macOS {
     signing { 
          sign.set(true)
-         identity.set("John Doe")
+         identity.set("John Doe (123)")
          // keychain.set("/path/to/keychain") 
     }
 }
@@ -175,11 +183,11 @@ macOS {
 
 * Set the `sign` DSL property or  to `true`.
     * Alternatively, the `compose.desktop.mac.sign` Gradle property can be used.
-* Set the `identity` DSL property to the certificate's name, e.g. `"John Doe"`.
+* Set the `identity` DSL property to the certificate's name, e.g. `"John Doe (123)"`.
     *  Alternatively,  the `compose.desktop.mac.signing.identity` Gradle property can be  used.
 * Optionally, set the `keychain` DSL property to the path to the specific keychain, containing your certificate.
     * Alternatively, the `compose.desktop.mac.signing.keychain` Gradle property can be used.
-    * This step is only necessary, if multiple `Developer ID Application` certificates are installed.
+    * This step is only necessary, if multiple developer certificates of the same type are installed.
   
 The following Gradle properties can be used instead of DSL properties:
 * `compose.desktop.mac.sign` enables or disables signing. 


### PR DESCRIPTION
This is a work-in-progress PR which adds support for publishing to the Apple App Store. For more information see #1599.

This PR adds the following:
- `appStore` option which passes the `--mac-app-store` option to jpackage.
- `appCategory` option which passes the `--mac-app-category category` option to jpackage and sets the `LSApplicationCategoryType` value in `Info.plist`.
- Possibly a fix for the `--app-image` option? I needed to change this to get the build working.

# Notes
* At least JDK 17 is required (https://bugs.openjdk.java.net/browse/JDK-8248904).
* With JDK 17 I ran into some signing issues (codesign reports `libskiko-macos-x64.dylib: is already signed`). Still need to look into this further. For me JDK 18 worked fine, so I just used that for now. Any ideas? Edit: issue here: https://github.com/JetBrains/compose-jb/issues/1666
* There is a bug in macOS Montery 12.0 which causes `productbuild` to fail with `'*** -[NSMutableOrderedSet unionOrderedSet:]: ordered set argument is not an NSOrderedSet’`. Solution: update to macOS Montery 12.1. See for more information: https://github.com/xamarin/xamarin-macios/issues/13197.

# TODO
The following errors were still reported by the App Store when using Transporter, with an app built with this PR:
* > WARNING ITMS-90889: ""Cannot be used with TestFlight because the bundle at “HueEssentials.app” is missing a provisioning profile. Main bundles are expected to have provisioning profiles in order to be eligible for TestFlight.""

I would appreciate some help with the error above.