### PR TITLE
Add mavenCentral() to pluginManagement

### DIFF
--- a/gradle-plugins/settings.gradle.kts
+++ b/gradle-plugins/settings.gradle.kts
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
Before this changes:
On clean build error occurs: Could not get resource "...kotlin-compiler-embeddable/1.5.10/...jar"
(Reproduced on MacOS, jvm11)

Add mavenCentral() to fix problem
