### PR TITLE
Reuse rendercomposable in tests

### DIFF
--- a/web/core/src/jsTest/kotlin/DomSideEffectTests.kt
+++ b/web/core/src/jsTest/kotlin/DomSideEffectTests.kt
@@ -2,7 +2,6 @@ package org.jetbrains.compose.web.core.tests
 
 import androidx.compose.runtime.*
 import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.renderComposable
 import kotlinx.browser.document
 import kotlinx.dom.clear
 import org.jetbrains.compose.web.testutils.*

--- a/web/core/src/jsTest/kotlin/elements/InputsGenerateCorrectHtmlTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/InputsGenerateCorrectHtmlTests.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.getValue
 import org.jetbrains.compose.web.attributes.*
 import org.jetbrains.compose.web.dom.*
-import org.jetbrains.compose.web.renderComposable
 import org.w3c.dom.HTMLInputElement
 import org.w3c.dom.HTMLTextAreaElement
 import kotlin.test.Test

--- a/web/test-utils/build.gradle.kts
+++ b/web/test-utils/build.gradle.kts
@@ -30,6 +30,7 @@ kotlin {
         val jsMain by getting {
             dependencies {
                 implementation(project(":internal-web-core-runtime"))
+                implementation(project(":web-core"))
                 implementation(kotlin("stdlib-js"))
             }
         }

--- a/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
+++ b/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
@@ -1,14 +1,30 @@
 package org.jetbrains.compose.web.testutils
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.ControlledComposition
+import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.runtime.Recomposer
 import kotlinx.browser.document
 import kotlinx.browser.window
-import kotlinx.coroutines.*
-import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.promise
 import kotlinx.dom.clear
-import kotlinx.dom.createElement
-import org.jetbrains.compose.web.internal.runtime.*
-import org.w3c.dom.*
+import org.jetbrains.compose.web.internal.runtime.ComposeWebInternalApi
+import org.jetbrains.compose.web.internal.runtime.DomApplier
+import org.jetbrains.compose.web.internal.runtime.DomNodeWrapper
+import org.jetbrains.compose.web.internal.runtime.GlobalSnapshotManager
+import org.jetbrains.compose.web.internal.runtime.JsMicrotasksDispatcher
+import org.jetbrains.compose.web.renderComposable
+import org.w3c.dom.Element
+import org.w3c.dom.HTMLElement
+import org.w3c.dom.MutationObserver
+import org.w3c.dom.MutationObserverInit
+import org.w3c.dom.asList
+import org.w3c.dom.get
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
@@ -50,7 +66,11 @@ class TestScope : CoroutineScope by MainScope() {
     fun composition(content: @Composable () -> Unit) {
         root.clear()
 
-        renderTestComposable(root = root) {
+        renderComposable(
+            root = root, monotonicFrameClock = TestMonotonicClockImpl(
+                onRecomposeComplete = this::onRecompositionComplete
+            )
+        ) {
             content()
         }
     }

--- a/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
+++ b/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
@@ -76,41 +76,6 @@ class TestScope : CoroutineScope by MainScope() {
     }
 
     /**
-     * Use this method to test the composition mounted at [root]
-     *
-     * @param root - the [Element] that will be the root of the DOM tree managed by Compose
-     * @param content - the Composable lambda that defines the composition content
-     *
-     * @return the instance of the [Composition]
-     */
-    @OptIn(ComposeWebInternalApi::class)
-    @ComposeWebExperimentalTestsApi
-    fun <TElement : Element> renderTestComposable(
-        root: TElement,
-        content: @Composable () -> Unit
-    ): Composition {
-        GlobalSnapshotManager.ensureStarted()
-
-        val context = TestMonotonicClockImpl(
-            onRecomposeComplete = this::onRecompositionComplete
-        ) + JsMicrotasksDispatcher()
-
-        val recomposer = Recomposer(context)
-        val composition = ControlledComposition(
-            applier = DomApplier(DomNodeWrapper(root)),
-            parent = recomposer
-        )
-        composition.setContent @Composable {
-            content()
-        }
-
-        CoroutineScope(context).launch(start = CoroutineStart.UNDISPATCHED) {
-            recomposer.runRecomposeAndApplyChanges()
-        }
-        return composition
-    }
-
-    /**
      * @return a reference to the next child element of the root.
      * Subsequent calls will return next child reference every time.
      */

--- a/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
+++ b/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
@@ -44,7 +44,7 @@ class TestScope : CoroutineScope by MainScope() {
      * It's used as a parent element for the composition.
      * It's added into the document's body automatically.
      */
-    val root = document.createElement("div")
+    val root = document.createElement("div") as HTMLElement
 
     private var waitForRecompositionCompleteContinuation: Continuation<Unit>? = null
     private val childrenIterator = root.children.asList().listIterator()
@@ -140,7 +140,7 @@ class TestScope : CoroutineScope by MainScope() {
     /**
      * Suspends until [element] observes any change to its html.
      */
-    suspend fun waitForChanges(element: Element) {
+    suspend fun waitForChanges(element: HTMLElement) {
         suspendCoroutine<Unit> { continuation ->
             val observer = MutationObserver { mutations, observer ->
                 continuation.resume(Unit)

--- a/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
+++ b/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
@@ -6,6 +6,7 @@ import kotlinx.browser.window
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.dom.clear
+import kotlinx.dom.createElement
 import org.jetbrains.compose.web.internal.runtime.*
 import org.w3c.dom.*
 import kotlin.coroutines.Continuation
@@ -27,7 +28,7 @@ class TestScope : CoroutineScope by MainScope() {
      * It's used as a parent element for the composition.
      * It's added into the document's body automatically.
      */
-    val root = "div".asHtmlElement()
+    val root = document.createElement("div")
 
     private var waitForRecompositionCompleteContinuation: Continuation<Unit>? = null
     private val childrenIterator = root.children.asList().listIterator()
@@ -119,7 +120,7 @@ class TestScope : CoroutineScope by MainScope() {
     /**
      * Suspends until [element] observes any change to its html.
      */
-    suspend fun waitForChanges(element: HTMLElement) {
+    suspend fun waitForChanges(element: Element) {
         suspendCoroutine<Unit> { continuation ->
             val observer = MutationObserver { mutations, observer ->
                 continuation.resume(Unit)
@@ -176,9 +177,6 @@ fun runTest(block: suspend TestScope.() -> Unit): dynamic {
     val scope = TestScope()
     return scope.promise { block(scope) }
 }
-
-@ComposeWebExperimentalTestsApi
-fun String.asHtmlElement() = document.createElement(this) as HTMLElement
 
 private object MutationObserverOptions : MutationObserverInit {
     override var childList: Boolean? = true


### PR DESCRIPTION
The main goal of this PR is to reuse "regular" renderComposable  in composition helper function from tests.  I left renderTestComposable (since technically it's the part of public API) but let's discuss whether we need it. 