### PR TITLE
Make DomElementWrapper private

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleBuilder.kt
@@ -7,9 +7,7 @@
 
 package org.jetbrains.compose.web.css
 
-import org.jetbrains.compose.web.internal.runtime.DomElementWrapper
 import org.jetbrains.compose.web.internal.runtime.ComposeWebInternalApi
-import org.w3c.dom.css.CSSStyleDeclaration
 import kotlin.properties.ReadOnlyProperty
 
 /**

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -51,47 +51,42 @@ private class DomElementWrapper(override val node: Element): DomNodeWrapper(node
             node.addEventListener(it.name, it)
         }
     }
-}
 
+    fun updateProperties(applicators: List<Pair<(Element, Any) -> Unit, Any>>) {
+        node.removeAttribute("class")
 
-
-@OptIn(ComposeWebInternalApi::class)
-private fun DomElementWrapper.updateProperties(applicators: List<Pair<(Element, Any) -> Unit, Any>>) {
-    node.removeAttribute("class")
-
-    applicators.forEach { (applicator, item) ->
-        applicator(node, item)
+        applicators.forEach { (applicator, item) ->
+            applicator(node, item)
+        }
     }
-}
 
-@OptIn(ComposeWebInternalApi::class)
-private fun DomElementWrapper.updateStyleDeclarations(styleApplier: StyleHolder) {
-    when (node) {
-        is HTMLElement, is SVGElement -> {
-            node.removeAttribute("style")
+    fun updateStyleDeclarations(styleApplier: StyleHolder) {
+        when (node) {
+            is HTMLElement, is SVGElement -> {
+                node.removeAttribute("style")
 
-            val style = node.unsafeCast<ElementCSSInlineStyle>().style
+                val style = node.unsafeCast<ElementCSSInlineStyle>().style
 
-            styleApplier.properties.forEach { (name, value) ->
-                style.setProperty(name, value.toString())
-            }
+                styleApplier.properties.forEach { (name, value) ->
+                    style.setProperty(name, value.toString())
+                }
 
-            styleApplier.variables.forEach { (name, value) ->
-                style.setProperty(name, value.toString())
+                styleApplier.variables.forEach { (name, value) ->
+                    style.setProperty(name, value.toString())
+                }
             }
         }
     }
-}
 
-@OptIn(ComposeWebInternalApi::class)
-private fun DomElementWrapper.updateAttrs(attrs: Map<String, String>) {
-    node.getAttributeNames().forEach { name ->
-        if (name == "style") return@forEach
-        node.removeAttribute(name)
-    }
+    fun updateAttrs(attrs: Map<String, String>) {
+        node.getAttributeNames().forEach { name ->
+            if (name == "style") return@forEach
+            node.removeAttribute(name)
+        }
 
-    attrs.forEach {
-        node.setAttribute(it.key, it.value)
+        attrs.forEach {
+            node.setAttribute(it.key, it.value)
+        }
     }
 }
 

--- a/web/internal-web-core-runtime/src/jsMain/kotlin/org/jetbrains/compose/web/internal/runtime/DomApplier.kt
+++ b/web/internal-web-core-runtime/src/jsMain/kotlin/org/jetbrains/compose/web/internal/runtime/DomApplier.kt
@@ -72,20 +72,3 @@ open class DomNodeWrapper(open val node: Node) {
         }
     }
 }
-
-@ComposeWebInternalApi
-class DomElementWrapper(override val node: Element): DomNodeWrapper(node) {
-    private var currentListeners = emptyList<NamedEventListener>()
-
-    fun updateEventListeners(list: List<NamedEventListener>) {
-        currentListeners.forEach {
-            node.removeEventListener(it.name, it)
-        }
-
-        currentListeners = list
-
-        currentListeners.forEach {
-            node.addEventListener(it.name, it)
-        }
-    }
-}


### PR DESCRIPTION
The goal of this PR is to hide DomElementWrapper out of public scope completely since it used only in Base.kt and there are no scenarios (at least designed and foreseen by us) where public users will need to use/modify this entity somehow. 