### PR TITLE
Treat warning as errors globally in web

### DIFF
--- a/web/benchmark-core/src/jsTest/kotlin/BenchmarkTests.kt
+++ b/web/benchmark-core/src/jsTest/kotlin/BenchmarkTests.kt
@@ -40,7 +40,7 @@ class BenchmarkTests {
 
         val avgMs = durations.map { it.toInt(DurationUnit.MILLISECONDS) }.average().toInt()
 
-        val browserName = window.navigator.userAgent.toLowerCase().let {
+        val browserName = window.navigator.userAgent.lowercase().let {
             when {
                 it.contains("chrome") -> "chrome"
                 it.contains("firefox") -> "firefox"

--- a/web/compose-compiler-integration/src/jsMain/kotlin/CrossmoduleTestsDependencies.kt
+++ b/web/compose-compiler-integration/src/jsMain/kotlin/CrossmoduleTestsDependencies.kt
@@ -37,7 +37,7 @@ class ClassSavesComposableIntoVar(c: @Composable () -> Unit) {
 }
 
 class ClassSavesComposableIntoLateinitVar(c: @Composable () -> Unit) {
-    lateinit var composableVar: @Composable () -> Unit
+    var composableVar: @Composable () -> Unit
 
     init {
         composableVar = c
@@ -58,7 +58,7 @@ class ClassSavesTypedComposableIntoVar<T>(c: @Composable (T) -> Unit) {
 
 
 class ClassSavesTypedComposableIntoLateinitVar<T>(c: @Composable (T) -> Unit) {
-    lateinit var composableVar: @Composable (T) -> Unit
+    var composableVar: @Composable (T) -> Unit
 
     init {
         composableVar = c

--- a/web/core/build.gradle.kts
+++ b/web/core/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
 kotlin {
     jvm()
     js(IR) {
+        compilations.getByName("test") {
+            kotlinOptions {
+                freeCompilerArgs += "-opt-in=org.jetbrains.compose.web.testutils.ComposeWebExperimentalTestsApi"
+            }
+        }
+
         browser() {
             testTask {
                 useKarma {
@@ -17,6 +23,7 @@ kotlin {
             }
         }
         binaries.executable()
+
     }
 
     sourceSets {
@@ -44,12 +51,6 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(compose.desktop.currentOs)
-            }
-        }
-
-        all {
-            languageSettings {
-                useExperimentalAnnotation("org.jetbrains.compose.web.testutils.ComposeWebExperimentalTestsApi")
             }
         }
     }

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheet.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheet.kt
@@ -168,7 +168,8 @@ internal fun buildCSS(
 }
 
 @Composable
-fun Style(
+@Suppress("NOTHING_TO_INLINE")
+inline fun Style(
     styleSheet: CSSRulesHolder
 ) {
     Style(cssRules = styleSheet.cssRules)

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheet.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/StyleSheet.kt
@@ -168,7 +168,7 @@ internal fun buildCSS(
 }
 
 @Composable
-inline fun Style(
+fun Style(
     styleSheet: CSSRulesHolder
 ) {
     Style(cssRules = styleSheet.cssRules)

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/animation.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/animation.kt
@@ -31,31 +31,31 @@ data class CSSAnimation(
     }
 }
 
-inline fun CSSAnimation.duration(vararg values: CSSSizeValue<out CSSUnitTime>) {
+fun CSSAnimation.duration(vararg values: CSSSizeValue<out CSSUnitTime>) {
     this.duration = values.toList()
 }
 
-inline fun CSSAnimation.timingFunction(vararg values: AnimationTimingFunction) {
+fun CSSAnimation.timingFunction(vararg values: AnimationTimingFunction) {
     this.timingFunction = values.toList()
 }
 
-inline fun CSSAnimation.delay(vararg values: CSSSizeValue<out CSSUnitTime>) {
+fun CSSAnimation.delay(vararg values: CSSSizeValue<out CSSUnitTime>) {
     this.delay = values.toList()
 }
 
-inline fun CSSAnimation.iterationCount(vararg values: Int?) {
+fun CSSAnimation.iterationCount(vararg values: Int?) {
     this.iterationCount = values.toList()
 }
 
-inline fun CSSAnimation.direction(vararg values: AnimationDirection) {
+fun CSSAnimation.direction(vararg values: AnimationDirection) {
     this.direction = values.toList()
 }
 
-inline fun CSSAnimation.fillMode(vararg values: AnimationFillMode) {
+fun CSSAnimation.fillMode(vararg values: AnimationFillMode) {
     this.fillMode = values.toList()
 }
 
-inline fun CSSAnimation.playState(vararg values: AnimationPlayState) {
+fun CSSAnimation.playState(vararg values: AnimationPlayState) {
     this.playState = values.toList()
 }
 
@@ -67,9 +67,9 @@ fun StyleBuilder.animation(
     property("animation", animation)
 }
 
-inline fun StyleBuilder.animation(
+fun StyleBuilder.animation(
     keyframes: CSSNamedKeyframes,
-    noinline builder: CSSAnimation.() -> Unit
+    builder: CSSAnimation.() -> Unit
 ) = animation(keyframes.name, builder)
 
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/border.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/border.kt
@@ -23,15 +23,15 @@ class CSSBorder : CSSStyleValue {
     }
 }
 
-inline fun CSSBorder.width(size: CSSNumeric) {
+fun CSSBorder.width(size: CSSNumeric) {
     width = size
 }
 
-inline fun CSSBorder.style(style: LineStyle) {
+fun CSSBorder.style(style: LineStyle) {
     this.style = style
 }
 
-inline fun CSSBorder.color(color: CSSColorValue) {
+fun CSSBorder.color(color: CSSColorValue) {
     this.color = color
 }
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -11,14 +11,13 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.css.ElementCSSInlineStyle
 import org.w3c.dom.svg.SVGElement
 
-@OptIn(ComposeCompilerApi::class)
 @Composable
 @ExplicitGroupsComposable
-private inline fun <TScope, T> ComposeDomNode(
-    noinline factory: () -> T,
+private fun <TScope, T> ComposeDomNode(
+    factory: () -> T,
     elementScope: TScope,
-    noinline attrsSkippableUpdate: @Composable SkippableUpdater<T>.() -> Unit,
-    noinline content: (@Composable TScope.() -> Unit)?
+    attrsSkippableUpdate: @Composable SkippableUpdater<T>.() -> Unit,
+    content: (@Composable TScope.() -> Unit)?
 ) {
     currentComposer.startNode()
     if (currentComposer.inserting) {

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/ElementScope.kt
@@ -92,7 +92,6 @@ abstract class ElementScopeBase<out TElement : Element> : ElementScope<TElement>
 
     @Composable
     @NonRestartableComposable
-    @OptIn(ComposeCompilerApi::class)
     override fun DomSideEffect(
         key: Any?,
         effect: DomEffectScope.(TElement) -> Unit

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
@@ -63,6 +63,7 @@ import org.w3c.dom.css.CSSStyleSheet
 typealias AttrBuilderContext<T> = AttrsBuilder<T>.() -> Unit
 typealias ContentBuilder<T> = @Composable ElementScope<T>.() -> Unit
 
+@Suppress("UNCHECKED_CAST")
 private open class ElementBuilderImplementation<TElement : Element>(private val tagName: String) : ElementBuilder<TElement> {
     private val el: Element by lazy { document.createElement(tagName) }
     override fun create(): TElement = el.cloneNode() as TElement

--- a/web/core/src/jsTest/kotlin/CssSelectorsTests.kt
+++ b/web/core/src/jsTest/kotlin/CssSelectorsTests.kt
@@ -24,6 +24,7 @@ class CssSelectorsTests {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun testPlusOperator() = runTest {
         val selectorScope = object : SelectorsScope {}
 

--- a/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
+++ b/web/core/src/jsTest/kotlin/css/CSSDisplayTests.kt
@@ -32,7 +32,7 @@ class CSSDisplayTests {
             }
         }
 
-        enumValues.forEachIndexed { index, displayStyle ->
+        enumValues.forEachIndexed { _, displayStyle ->
             assertEquals(
                 displayStyle.value,
                 (nextChild()).style.display

--- a/web/core/src/jsTest/kotlin/css/PositionTests.kt
+++ b/web/core/src/jsTest/kotlin/css/PositionTests.kt
@@ -74,7 +74,7 @@ class PositionTests {
             }
         }
 
-        enumValues.forEachIndexed { index, position ->
+        enumValues.forEachIndexed { _, position ->
             assertEquals(
                 "position: ${position.value};",
                 nextChild().style.cssText

--- a/web/core/src/jsTest/kotlin/elements/AttributesTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/AttributesTests.kt
@@ -250,7 +250,7 @@ class AttributesTests {
             if (flag) {
                 Div(attrs = {
                     ref { div ->
-                        (div as HTMLDivElement).innerText = "Text set using ref {}"
+                        div.innerText = "Text set using ref {}"
                         onDispose {
                             div.innerText = ""
                         }
@@ -309,7 +309,7 @@ class AttributesTests {
 
             Div(attrs = {
                 attrsCallCounter += 1
-                ref { div ->
+                ref {
                     refInitCounter += 1
                     onDispose {
                         refDisposeCounter += 1

--- a/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/Sample.kt
+++ b/web/integration-core/src/jsMain/kotlin/androidx/compose/web/sample/Sample.kt
@@ -201,7 +201,7 @@ fun main() {
                 opacity(0.3)
             }
 
-            className(MyClassName) + hover() style {
+            className(MyClassName) + hover style {
                 opacity(1)
             }
 

--- a/web/integration-widgets/src/commonMain/kotlin/App.kt
+++ b/web/integration-widgets/src/commonMain/kotlin/App.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 package org.jetbrainsc.compose.common.demo
 
 import androidx.compose.runtime.Composable

--- a/web/integration-widgets/src/jsMain/kotlin/androidx/compose/web/with-web/demo.kt
+++ b/web/integration-widgets/src/jsMain/kotlin/androidx/compose/web/with-web/demo.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 /*
  * Copyright 2021 The Android Open Source Project
  *

--- a/web/svg/build.gradle.kts
+++ b/web/svg/build.gradle.kts
@@ -8,6 +8,12 @@ plugins {
 
 kotlin {
     js(IR) {
+        compilations.getByName("test") {
+            kotlinOptions {
+                freeCompilerArgs += "-opt-in=org.jetbrains.compose.web.testutils.ComposeWebExperimentalTestsApi"
+            }
+        }
+
         browser() {
             testTask {
                 useKarma {
@@ -38,12 +44,6 @@ kotlin {
             dependencies {
                 implementation(project(":test-utils"))
                 implementation(kotlin("test-js"))
-            }
-        }
-
-        all {
-            languageSettings {
-                useExperimentalAnnotation("org.jetbrains.compose.web.testutils.ComposeWebExperimentalTestsApi")
             }
         }
     }

--- a/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
+++ b/web/test-utils/src/jsMain/kotlin/org/jetbrains/compose/web/testutils/TestUtils.kt
@@ -80,6 +80,7 @@ class TestScope : CoroutineScope by MainScope() {
      * Subsequent calls will return next child reference every time.
      */
     fun nextChild() = childrenIterator.next() as HTMLElement
+    @Suppress("UNCHECKED_CAST")
     fun <T> nextChild() = childrenIterator.next() as T
 
     /**
@@ -107,7 +108,7 @@ class TestScope : CoroutineScope by MainScope() {
      */
     suspend fun waitForChanges(element: HTMLElement) {
         suspendCoroutine<Unit> { continuation ->
-            val observer = MutationObserver { mutations, observer ->
+            val observer = MutationObserver { _, observer ->
                 continuation.resume(Unit)
                 observer.disconnect()
             }


### PR DESCRIPTION
The only exception is web-widgets, which are all deprecated but suppressing this deprecation via annotation won't do a good service to users (and there's no way in modern Kotlin tooling to ignore this warning only).

The other change  useExperimentalAnnotation in build (which is going to be deprecated) with recommended optIn option