### PR TITLE
Add `checkAndWarnAboutUsingJsPlugin` to gradle plugin

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -25,9 +25,11 @@ import org.jetbrains.compose.desktop.application.internal.currentTarget
 import org.jetbrains.compose.desktop.preview.internal.initializePreview
 import org.jetbrains.compose.experimental.dsl.ExperimentalExtension
 import org.jetbrains.compose.experimental.internal.configureExperimental
+import org.jetbrains.compose.internal.COMPOSE_PLUGIN_ID
+import org.jetbrains.compose.internal.KOTLIN_JS_PLUGIN_ID
+import org.jetbrains.compose.internal.KOTLIN_MPP_PLUGIN_ID
 import org.jetbrains.compose.web.WebExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
-import org.jetbrains.kotlin.gradle.plugin.KotlinJsPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal val composeVersion get() = ComposeBuildConfig.composeVersion
@@ -140,15 +142,11 @@ class ComposePlugin : Plugin<Project> {
     }
 
     private fun checkAndWarnAboutUsingJsPlugin(project: Project) {
-        val msg = "Project has kotlin(\"js\") plugin applied.\n" +
-                "It's necessary to apply kotlin(\"multiplatform\") plugin " +
-                "in order to use \"org.jetbrains.compose\" plugin with k/js targets.\n" +
-                "See https://github.com/JetBrains/compose-jb/blob/master/tutorials/Web/README.md"
+        val msg = "'$COMPOSE_PLUGIN_ID' plugin is not compatible with '$KOTLIN_JS_PLUGIN_ID' plugin. " +
+                "Use '$KOTLIN_MPP_PLUGIN_ID' instead"
 
-        project.plugins.all {
-            if (it is KotlinJsPluginWrapper) {
-                project.logger.error(msg)
-            }
+        project.plugins.withId(KOTLIN_JS_PLUGIN_ID) {
+            project.logger.error(msg)
         }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -27,6 +27,7 @@ import org.jetbrains.compose.experimental.dsl.ExperimentalExtension
 import org.jetbrains.compose.experimental.internal.configureExperimental
 import org.jetbrains.compose.web.WebExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.plugin.KotlinJsPluginWrapper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal val composeVersion get() = ComposeBuildConfig.composeVersion
@@ -132,6 +133,21 @@ class ComposePlugin : Plugin<Project> {
                     }
                     useIR = true
                 }
+            }
+        }
+
+        checkAndWarnAboutUsingJsPlugin(project)
+    }
+
+    private fun checkAndWarnAboutUsingJsPlugin(project: Project) {
+        val msg = "Project has kotlin(\"js\") plugin applied.\n" +
+                "It's necessary to apply kotlin(\"multiplatform\") plugin " +
+                "in order to use \"org.jetbrains.compose\" plugin with k/js targets.\n" +
+                "See https://github.com/JetBrains/compose-jb/blob/master/tutorials/Web/README.md"
+
+        project.plugins.all {
+            if (it is KotlinJsPluginWrapper) {
+                project.logger.error(msg)
             }
         }
     }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/constants.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/constants.kt
@@ -7,3 +7,5 @@ package org.jetbrains.compose.internal
 
 internal const val KOTLIN_MPP_PLUGIN_ID = "org.jetbrains.kotlin.multiplatform"
 internal const val KOTLIN_JVM_PLUGIN_ID = "org.jetbrains.kotlin.jvm"
+internal const val KOTLIN_JS_PLUGIN_ID = "org.jetbrains.kotlin.js"
+internal const val COMPOSE_PLUGIN_ID = "org.jetbrains.compose"


### PR DESCRIPTION
Tried to use `project.plugins.whenObjectAdded {  }`, but it receives only plugins added after our plugin, so order matters.
At the same time `project.plugins.all { }` receives all plugins (added before and after our one) 

closes #1693

