### PR TITLE
Added link to Gradle tool window﻿

### DIFF
--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -144,7 +144,7 @@ fun main() = application {
 ```
 ## Running the project
 
-Open `build.gradle.kts` as a project in IntelliJ IDEA.
+Open `build.gradle.kts` [as a project](https://www.jetbrains.com/help/idea/jetgradle-tool-window.html) in IntelliJ IDEA.
 
 <img alt="New project" src="screen1.png" height="500" />
 


### PR DESCRIPTION
As someone new to Compose, I did not know how I'm supposed to "Open `build.gradle.kts` as a project". It'd be helpful to add a link since this is a tutorial.