### PR TITLE
Fix issue where Todo List Android app is not launchable

### DIFF
--- a/examples/todoapp/android/src/main/AndroidManifest.xml
+++ b/examples/todoapp/android/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
         <activity
             android:name="example.todo.android.MainActivity"
             android:label="@string/app_name"
-            android:exported="false">
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Launcher `Activity` should have `android:exported` attributes set to `true` so that app launchers have permission to launch the `Activity`.

Check official docs for more information: https://developer.android.com/guide/topics/manifest/activity-element#exported