### PR TITLE
Update ProGuard version in example

### DIFF
--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -590,9 +590,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.guardsquare:proguard-gradle:7.1.1") {
-            exclude("com.android.tools.build")
-        }
+        classpath("com.guardsquare:proguard-gradle:7.2.0")
     }
 }
 


### PR DESCRIPTION
Update ProGuard version and remove exclude for Android build tools dependency. The exclude should no longer be required (https://github.com/Guardsquare/proguard/issues/66).