### PR TITLE
Fix issue on proguard example

### DIFF
--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -600,7 +600,7 @@ buildscript {
 
 // Define task to obfuscate the JAR and output to <name>.min.jar
 tasks.register<ProGuardTask>("obfuscate") {
-    val packageUberJarForCurrentOS by getting
+    val packageUberJarForCurrentOS by tasks.getting
     dependsOn(packageUberJarForCurrentOS)
     val files = packageUberJarForCurrentOS.outputs.files
     injars(files)


### PR DESCRIPTION
The example here is really helpful, but there's something missing in the snippet from `build.gradle.kts` so that it doesn't compile. Got a fix on Slack, let's fix it here, too.