### PR TITLE
Fix publishing multiple platforms that use same alternative name

### DIFF
--- a/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -48,9 +48,9 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
                     return ALL
                 }
 
-                val publication = ALL.firstOrNull { it.matches(name) }
-                if (publication != null) {
-                    platforms.add(publication)
+                val matchingPlatforms = ALL.filter { it.matches(name) }
+                if (matchingPlatforms.isNotEmpty()) {
+                    platforms.addAll(matchingPlatforms)
                 } else {
                     unknownNames.add(name)
                 }


### PR DESCRIPTION
-Pcompose.platforms=macos only matched MacosX64,
when it was expected to match both MacosX64 & MacosArm64