### PR TITLE
Fix fromFiles argument not lazy

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -227,7 +227,7 @@ internal fun AbstractJPackageTask.configurePackagingTask(
     javaHome.set(provider { app.javaHomeOrDefault() })
 
     launcherMainJar.set(app.mainJar.orNull)
-    app._fromFiles.forEach { files.from(it) }
+    files.from(app._fromFiles)
     dependsOn(*app._dependenciesTaskNames.toTypedArray())
 
     app._configurationSource?.let { configSource ->


### PR DESCRIPTION
Use case is the following:

```kt
application {
    fromFiles(fileTree(tmpLibsDir))
}
```

Before this PR the file tree would be evaluated immediately which could cause it to miss files that are added by a task when building. This PR makes sure that the files passed are evaluated lazily.