### PR TITLE
Fix `packagePkg` task

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -136,7 +136,11 @@ internal fun Project.configurePackagingTasks(apps: Collection<Application>) {
                         checkRuntime = checkRuntime
                     )
                 } else {
-                    configurePackagingTask(app, createAppImage = createDistributable)
+                    configurePackagingTask(
+                        app,
+                        createAppImage = createDistributable,
+                        checkRuntime = checkRuntime
+                    )
                 }
             }
 


### PR DESCRIPTION
Fixes #1763

I am not sure why `checkRuntime` was left out here with this `configurePackagingTask` call, but adding it seems to fix it for me.