### PR TITLE
Fix jnilib files not signed

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
@@ -31,9 +31,22 @@ internal class MacJarSignFileCopyingProcessor(
                      * so we need to remove signature before running jpackage.
                      *
                      * JDK 18 processes signed libraries fine, so we don't have to do anything.
+                     *
+                     * Note that the JDK only signs dylib files and not jnilib files,
+                     * so jnilib files still need to be signed here.
                      */
-                    jvmRuntimeVersion == 17 -> signer.unsign(target)
-                    else -> {}
+                    jvmRuntimeVersion == 17 -> {
+                        if (source.name.endsWith(".jnilib")) {
+                            signer.sign(target)
+                        } else {
+                            signer.unsign(target)
+                        }
+                    }
+                    else -> {
+                        if (source.name.endsWith(".jnilib")) {
+                            signer.sign(target)
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
You can see here that only `dylib` files are signed:

https://github.com/openjdk/jdk/blob/f7814c120bf84d7e9b459f81a6ce19b44fa122ec/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/MacAppImageBuilder.java#L673-L677

So that means that `jnilib` files still need to be signed manually.