### PR TITLE
Fix could not find application image error on macOS

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractRunDistributableTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/tasks/AbstractRunDistributableTask.kt
@@ -34,6 +34,8 @@ abstract class AbstractRunDistributableTask @Inject constructor(
     fun run() {
         val appDir = appImageRootDir.ioFile.let { appImageRoot ->
             val files = appImageRoot.listFiles()
+                // Sometimes ".DS_Store" files are created on macOS, so ignore them.
+                ?.filterNot { it.name == ".DS_Store" }
             if (files == null || files.isEmpty()) {
                 error("Could not find application image: $appImageRoot is empty!")
             } else if (files.size > 1) {


### PR DESCRIPTION
Sometimes when building I get the following error:
```
Execution failed for task ':desktop:runDistributable'.
> Could not find application image: /Users/thomas/AndroidStudioProjects/HueEssentials/desktop/build/compose/binaries/main/app contains multiple children [/Users/thomas/AndroidStudioProjects/HueEssentials/desktop/build/compose/binaries/main/app/Hue Essentials.app, /Users/thomas/AndroidStudioProjects/HueEssentials/desktop/build/compose/binaries/main/app/.DS_Store]
```

I noticed this error occurs after using the Finder app to browse through the created app image, and then building again.

This PR fixes the error by ignoring `.DS_Store` files.