### PR TITLE
Fix TestFlight builds on the Mac App Store

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/dsl/PlatformSettings.kt
@@ -23,6 +23,7 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     var appStore: Boolean = false
     var appCategory: String? = null
     var entitlementsFile: RegularFileProperty = objects.fileProperty()
+    var runtimeEntitlementsFile: RegularFileProperty = objects.fileProperty()
     var packageBuildVersion: String? = null
     var dmgPackageVersion: String? = null
     var dmgPackageBuildVersion: String? = null
@@ -49,6 +50,7 @@ open class MacOSPlatformSettings @Inject constructor(objects: ObjectFactory): Pl
     }
 
     val provisioningProfile: RegularFileProperty = objects.fileProperty()
+    val runtimeProvisioningProfile: RegularFileProperty = objects.fileProperty()
 
     internal val infoPlistSettings = InfoPlistSettings()
     fun infoPlist(fn: Action<InfoPlistSettings>) {

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigner.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigner.kt
@@ -7,6 +7,7 @@ package org.jetbrains.compose.desktop.application.internal
 
 import org.jetbrains.compose.desktop.application.internal.validation.ValidatedMacOSSigningSettings
 import java.io.File
+import java.nio.file.Files
 import java.util.regex.Pattern
 
 internal class MacSigner(
@@ -31,7 +32,15 @@ internal class MacSigner(
         )
     }
 
-    fun sign(file: File) {
+    /**
+     * If [entitlements] file is provided, executables are signed with entitlements.
+     * Set [forceEntitlements] to `true` to sign all types of files with the provided [entitlements].
+     */
+    fun sign(
+        file: File,
+        entitlements: File? = null,
+        forceEntitlements: Boolean = false
+    ) {
         val args = arrayListOf(
             "-vvvv",
             "--timestamp",
@@ -44,6 +53,13 @@ internal class MacSigner(
         settings.keychain?.let {
             args.add("--keychain")
             args.add(it.absolutePath)
+        }
+
+        if (forceEntitlements || Files.isExecutable(file.toPath())) {
+            entitlements?.let {
+                args.add("--entitlements")
+                args.add(it.absolutePath)
+            }
         }
 
         args.add(file.absolutePath)

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigningHelper.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigningHelper.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.desktop.application.internal
+
+import org.jetbrains.compose.desktop.application.internal.files.isDylibPath
+import java.io.File
+import kotlin.io.path.isExecutable
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.isSymbolicLink
+
+internal class MacSigningHelper(
+    private val macSigner: MacSigner,
+    private val runtimeProvisioningProfile: File?,
+    private val entitlementsFile: File?,
+    private val runtimeEntitlementsFile: File?,
+    destinationDir: File,
+    packageName: String
+) {
+    private val appDir = destinationDir.resolve("$packageName.app")
+    private val runtimeDir = appDir.resolve("Contents/runtime")
+
+    fun modifyRuntimeIfNeeded() {
+        // Only resign modify the runtime if a provisioning profile or alternative entitlements file is provided.
+        // If no entitlements file is provided, the runtime cannot be resigned.
+        if (runtimeProvisioningProfile == null &&
+            // When resigning the runtime, an app entitlements file is also needed.
+            (runtimeEntitlementsFile == null || entitlementsFile == null)
+        ) {
+            return
+        }
+
+        // Add the provisioning profile
+        runtimeProvisioningProfile?.let {
+            addRuntimeProvisioningProfile(runtimeDir, it)
+        }
+
+        // Resign the runtime completely (and also the app dir only)
+        resignRuntimeAndAppDir(appDir, runtimeDir)
+    }
+
+    private fun addRuntimeProvisioningProfile(
+        runtimeDir: File,
+        runtimeProvisioningProfile: File
+    ) {
+        runtimeProvisioningProfile.copyTo(
+            target = runtimeDir.resolve("Contents/embedded.provisionprofile"),
+            overwrite = true
+        )
+    }
+
+    private fun resignRuntimeAndAppDir(
+        appDir: File,
+        runtimeDir: File
+    ) {
+        // Sign all libs and executables in runtime
+        runtimeDir.walk().forEach { file ->
+            val path = file.toPath()
+            if (path.isRegularFile() && (path.isExecutable() || path.toString().isDylibPath)) {
+                if (path.isSymbolicLink()) {
+                    // Ignore symbolic links
+                } else {
+                    // Resign file
+                    macSigner.unsign(file)
+                    macSigner.sign(file, runtimeEntitlementsFile)
+                }
+            }
+        }
+
+        // Resign runtime directory
+        macSigner.unsign(runtimeDir)
+        macSigner.sign(runtimeDir, runtimeEntitlementsFile, forceEntitlements = true)
+
+        // Resign app directory (contents other than runtime were already signed by jpackage)
+        macSigner.unsign(appDir)
+        macSigner.sign(appDir, entitlementsFile, forceEntitlements = true)
+    }
+}

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/configureApplication.kt
@@ -311,9 +311,11 @@ internal fun AbstractJPackageTask.configurePlatformSettings(app: Application) {
                 macAppStore.set(mac.appStore)
                 macAppCategory.set(mac.appCategory)
                 macEntitlementsFile.set(mac.entitlementsFile)
+                macRuntimeEntitlementsFile.set(mac.runtimeEntitlementsFile)
                 packageBuildVersion.set(packageBuildVersionFor(project, app, targetFormat))
                 nonValidatedMacBundleID.set(provider { mac.bundleID })
                 macProvisioningProfile.set(mac.provisioningProfile)
+                macRuntimeProvisioningProfile.set(mac.runtimeProvisioningProfile)
                 macExtraPlistKeysRawXml.set(provider { mac.infoPlistSettings.extraKeysRawXml })
                 nonValidatedMacSigningSettings = app.nativeDistributions.macOS.signing
                 iconFile.set(mac.iconFile.orElse(DefaultIcons.forMac(project)))

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/files/MacJarSignFileCopyingProcessor.kt
@@ -86,5 +86,5 @@ internal class MacJarSignFileCopyingProcessor(
     }
 }
 
-private val String.isDylibPath
+internal val String.isDylibPath
     get() = endsWith(".dylib") || endsWith(".jnilib")

--- a/tutorials/Native_distributions_and_local_execution/README.md
+++ b/tutorials/Native_distributions_and_local_execution/README.md
@@ -436,7 +436,7 @@ The following platform-specific options are available
     * `packageName` — a name of the application;
     * `dockName` — a name of the application displayed in the menu bar, the "About <App>" menu item, in the dock, etc. 
       Equals to `packageName` by default.
-    * `signing`, `notarization`, and `provisioningProfile` — see
+    * `signing`, `notarization`, `provisioningProfile`, and `runtimeProvisioningProfile` — see
       [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md) 
       for details;
     * `appStore = true` — build and sign for the Apple App Store. Requires at least JDK 17;
@@ -446,6 +446,13 @@ The following platform-specific options are available
     * `entitlementsFile.set(File("PATH_TO_ENTITLEMENTS"))` — a path to file containing entitlements to use when signing.
       When a custom file is provided, make sure to add the entitlements that are required for Java apps.
       See [sandbox.plist](https://github.com/openjdk/jdk/blob/master/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/sandbox.plist) for the default file that is used when building for the App Store. It can be different depending on your JDK version.
+      If no file is provided the default entitlements provided by jpackage are used.
+      See [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md#configuring-entitlements)
+    * `runtimeEntitlementsFile.set(File("PATH_TO_RUNTIME_ENTITLEMENTS"))` — a path to file containing entitlements to use when signing the JVM runtime.
+      When a custom file is provided, make sure to add the entitlements that are required for Java apps.
+      See [sandbox.plist](https://github.com/openjdk/jdk/blob/master/src/jdk.jpackage/macosx/classes/jdk/jpackage/internal/resources/sandbox.plist) for the default file that is used when building for the App Store. It can be different depending on your JDK version.
+      If no file is provided then `entitlementsFile` is used. If that was also not provided, the default entitlements provided by jpackage are used.
+      See [the corresponding tutorial](/tutorials/Signing_and_notarization_on_macOS/README.md#configuring-entitlements)
     * `dmgPackageVersion = "DMG_VERSION"` — a dmg-specific package version
       (see the section `Specifying package version` for details);
     * `pkgPackageVersion = "PKG_VERSION"` — a pkg-specific package version


### PR DESCRIPTION
This PR fixes TestFlight builds, see #1599 and #1613 for details.

Two new properties are added:
`macOS.runtimeEntitlementsFile` - entitlements file for the JVM runtime
`macOS.runtimeProvisioningProfile` - provisioning profile for the JVM runtime

Because jpackage does not support the properties above, the runtime (and app dir) needs to be resigned manually after the files are added.

I did update the documentation, but I could see that this is a bit hard to understand. So maybe that needs to be made more clear with some help.

Please let me know what you think about this. My app is available on TestFlight with this PR!