### PR TITLE
web: make `applyAttrs` in the second overloaded `TagElement` nullable to be consistent with the first one

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -148,7 +148,7 @@ fun <TElement : Element> TagElement(
 @ExperimentalComposeWebApi
 fun <TElement : Element> TagElement(
     tagName: String,
-    applyAttrs: AttrsScope<TElement>.() -> Unit,
+    applyAttrs: (AttrsScope<TElement>.() -> Unit)?,
     content: (@Composable ElementScope<TElement>.() -> Unit)?
 ) = TagElement(
     elementBuilder = ElementBuilder.createBuilder(tagName),


### PR DESCRIPTION
From what I understand, for non-inline functions passing `null` is a bit more efficient than passing an empty lambda, and that's why most functions in this library have the signature `attrs: AttrBuilderContext<HTMLElement>? = null`. Then there is no reason the second overloaded `TagElement` function shouldn't be like that, so I guess this is a small mistake that should be fixed.