### PR TITLE
web: update TagElement with tagName: String

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -154,8 +154,12 @@ fun <TElement : Element> TagElement(
     tagName: String,
     applyAttrs: AttrsScope<TElement>.() -> Unit,
     content: (@Composable ElementScope<TElement>.() -> Unit)?
-) = TagElement(
-    elementBuilder = ElementBuilder.createBuilder(tagName),
-    applyAttrs = applyAttrs,
-    content = content
-)
+) {
+    key(tagName) {
+        TagElement(
+            elementBuilder = ElementBuilder.createBuilder(tagName),
+            applyAttrs = applyAttrs,
+            content = content
+        )
+    }
+}

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Base.kt
@@ -148,8 +148,16 @@ fun <TElement : Element> TagElement(
     }
 }
 
+/**
+ * @param tagName - the name of the tag that needs to be created.
+ * It's best to use constant values for [tagName].
+ * If variable [tagName] needed, consider wrapping TagElement calls into an if...else:
+ *
+ * ```
+ *      if (useDiv) TagElement("div",...) else TagElement("span", ...)
+ * ```
+ */
 @Composable
-@ExperimentalComposeWebApi
 fun <TElement : Element> TagElement(
     tagName: String,
     applyAttrs: AttrsScope<TElement>.() -> Unit,

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
@@ -156,6 +156,7 @@ fun interface ElementBuilder<TElement : Element> {
     fun create(): TElement
 
     companion object {
+        // it's internal only for testing purposes
         internal val buildersCache = mutableMapOf<String, ElementBuilder<*>>()
 
         fun <TElement : Element> createBuilder(tagName: String): ElementBuilder<TElement> {

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
@@ -150,14 +150,18 @@ private val Td: ElementBuilder<HTMLTableCellElement> = ElementBuilderImplementat
 private val Tbody: ElementBuilder<HTMLTableSectionElement> = ElementBuilderImplementation("tbody")
 private val Tfoot: ElementBuilder<HTMLTableSectionElement> = ElementBuilderImplementation("tfoot")
 
-val Style: ElementBuilder<HTMLStyleElement> = ElementBuilderImplementation("style")
+internal val Style: ElementBuilder<HTMLStyleElement> = ElementBuilderImplementation("style")
 
 fun interface ElementBuilder<TElement : Element> {
     fun create(): TElement
 
     companion object {
+        internal val buildersCache = mutableMapOf<String, ElementBuilder<*>>()
+
         fun <TElement : Element> createBuilder(tagName: String): ElementBuilder<TElement> {
-            return object  : ElementBuilderImplementation<TElement>(tagName) {}
+            return buildersCache.getOrPut(tagName) {
+                ElementBuilderImplementation<TElement>(tagName)
+            }.unsafeCast<ElementBuilder<TElement>>()
         }
     }
 }

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/elements/Elements.kt
@@ -160,8 +160,9 @@ fun interface ElementBuilder<TElement : Element> {
         internal val buildersCache = mutableMapOf<String, ElementBuilder<*>>()
 
         fun <TElement : Element> createBuilder(tagName: String): ElementBuilder<TElement> {
-            return buildersCache.getOrPut(tagName) {
-                ElementBuilderImplementation<TElement>(tagName)
+            val tagLowercase = tagName.lowercase()
+            return buildersCache.getOrPut(tagLowercase) {
+                ElementBuilderImplementation<TElement>(tagLowercase)
             }.unsafeCast<ElementBuilder<TElement>>()
         }
     }

--- a/web/core/src/jsTest/kotlin/elements/ElementsTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/ElementsTests.kt
@@ -146,10 +146,10 @@ class ElementsTests {
         val expectedKeys = setOf("custom", "div", "b", "abc")
         assertEquals(expectedKeys, ElementBuilder.buildersCache.keys.intersect(expectedKeys))
 
-        assertEquals("custom", custom.create().nodeName.lowercase())
-        assertEquals("div", div.create().nodeName.lowercase())
-        assertEquals("b", b.create().nodeName.lowercase())
-        assertEquals("abc", abc.create().nodeName.lowercase())
+        assertEquals("CUSTOM", custom.create().nodeName)
+        assertEquals("DIV", div.create().nodeName)
+        assertEquals("B", b.create().nodeName)
+        assertEquals("ABC", abc.create().nodeName)
     }
 
     @Test

--- a/web/core/src/jsTest/kotlin/elements/ElementsTests.kt
+++ b/web/core/src/jsTest/kotlin/elements/ElementsTests.kt
@@ -137,6 +137,56 @@ class ElementsTests {
     }
 
     @Test
+    fun testElementBuilderCreate() {
+        val custom = ElementBuilder.createBuilder<HTMLElement>("custom")
+        val div = ElementBuilder.createBuilder<HTMLElement>("div")
+        val b = ElementBuilder.createBuilder<HTMLElement>("b")
+        val abc = ElementBuilder.createBuilder<HTMLElement>("abc")
+
+        val expectedKeys = setOf("custom", "div", "b", "abc")
+        assertEquals(expectedKeys, ElementBuilder.buildersCache.keys.intersect(expectedKeys))
+
+        assertEquals("custom", custom.create().nodeName.lowercase())
+        assertEquals("div", div.create().nodeName.lowercase())
+        assertEquals("b", b.create().nodeName.lowercase())
+        assertEquals("abc", abc.create().nodeName.lowercase())
+    }
+
+    @Test
+    @OptIn(ExperimentalComposeWebApi::class)
+    fun rawCreationAndTagChanges() = runTest {
+        @Composable
+        fun CustomElement(
+            tagName: String,
+            attrs: AttrsScope<HTMLElement>.() -> Unit,
+            content: ContentBuilder<HTMLElement>? = null
+        ) {
+            TagElement(
+                tagName = tagName,
+                applyAttrs = attrs,
+                content
+            )
+        }
+
+        var tagName by mutableStateOf("custom")
+
+        composition {
+            CustomElement(tagName, {
+                id("container")
+            }) {
+                Text("CUSTOM")
+            }
+        }
+
+        assertEquals("<div><custom id=\"container\">CUSTOM</custom></div>", root.outerHTML)
+
+        tagName = "anothercustom"
+        waitForRecompositionComplete()
+
+        assertEquals("<div><anothercustom id=\"container\">CUSTOM</anothercustom></div>", root.outerHTML)
+    }
+
+    @Test
     fun elementBuilderShouldBeCalledOnce() = runTest {
         var counter = 0
         var flag by mutableStateOf(false)


### PR DESCRIPTION
Enable changing the tagName value. This will delete the initial html element and create a new one with a new tagName.

Also cache ElementBuilder instances created using `ElementBuilder.create(tagName)`.