### PR TITLE
Design iOS gradle dsl

### DIFF
--- a/experimental/design-ios-gradle-dsl/build.gradle.kts
+++ b/experimental/design-ios-gradle-dsl/build.gradle.kts
@@ -1,0 +1,86 @@
+plugins {
+    kotlin("multiplatform")
+    id("org.jetbrains.compose")
+}
+
+kotlin {
+    iosX64()
+    iosArm64()
+}
+
+compose.ios {
+    application {
+        mainClass = "Main_ios.kt"
+        bundleID = "com.example-company.example-app"
+        version = "1.2.3"
+
+        val distributionSigning = createSigningConfiguration {
+            name = "Distribution company signing"
+            keychain = project.file("secrets.keychain")
+            keychainPassword = System.getenv("CI_SECRET") ?: "***" // Optional, it's beter to unlock keychain
+            certificateIdentity = "name_of_distribution_certificate_in_keychain"
+            provisionProfile = project.file("distribution.mobileprovision")
+            teamId = "TEAM_123"
+        }
+        val developmentSigning = createSigningConfiguration {
+            name = "Development company signing"
+            keychain = project.file("secrets.keychain")
+            keychainPassword = System.getenv("CI_SECRET") ?: "***" // Optional, it's beter to unlock keychain
+            certificateIdentity = "name_of_development_certificate_in_keychain"
+            provisionProfile = project.file("development.mobileprovision")
+            teamId = "TEAM_123"
+        }
+
+        deployConfigurations {
+            localFile("Local") {
+                //Usage: ./gradlew iosDeployLocal
+                outputFile = File("~/Desktop/release-signed.ipa")
+                buildConfiguration = "Release"
+                signingConfiguration = developmentSigning
+            }
+            simulator("IPhone11_en") {
+                //Usage: ./gradlew iosDeployIPhone11_en
+                device = IOSDevices.IPHONE_11
+                iosVersion = "15.1"
+                simulatorLanguage = "en_US"
+                buildConfiguration = "Debug"
+                signingConfiguration = SigningConfiguration.UNSIGNED
+            }
+            simulator("IPad_ru") {
+                //Usage: ./gradlew iosDeployIPad_ru
+                device = IOSDevices.IPAD_4
+                iosVersion = "15.1"
+                simulatorLanguage = "ru_RU"
+                buildConfiguration = "Debug"
+                signingConfiguration = SigningConfiguration.UNSIGNED
+            }
+            connectedDevice("TrustedDevice") {
+                //Usage: ./gradlew iosDeployTrustedDevice
+                buildConfiguration = "Debug"
+                signingConfiguration = developmentSigning
+            }
+            appleTestFlight("Prod") {
+                //Usage: ./gradlew iosDeployProd
+                appStoreConnectApiKey = "***" // or "@keychain:APPSTORE_API_KEY"
+                description = "description in test flight"
+                buildConfiguration = "Release"
+                signingConfiguration = distributionSigning
+            }
+            appleTestFlight("Beta") {
+                //Usage: ./gradlew iosDeployBeta
+                appStoreConnectApiKey = "***" // or "@keychain:APPSTORE_API_KEY"
+                description = "description in test flight"
+                buildConfiguration = "Debug"
+                signingConfiguration = developmentSigning
+            }
+            firebaseAppDistribution("Firebase") {
+                //Usage: ./gradlew iosDeployFirebase
+                googleCloudApiKey = "***" // or "@keychain:GCLOUD_API_KEY"
+                firebaseProjectId = "some_firebase_project"
+                buildConfiguration = "Debug"
+                signingConfiguration = developmentSigning
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Prepare DSL api to configure iOS deployments.
Everything may be discussed.

Every deployConfiguration("ID") will available to gradle (./gradlew iosDeployID),
For example:
```
simulator("IPhone11_en") {
   ...
}
```
generate gradle task **iosDeployIPhone11_en**