### PR TITLE
TodoApp. Updated Decompose to 0.5.1 and MVIKotlin to 3.0.0-beta01.

### DIFF
--- a/examples/todoapp/android/src/main/java/example/todo/android/MainActivity.kt
+++ b/examples/todoapp/android/src/main/java/example/todo/android/MainActivity.kt
@@ -34,7 +34,7 @@ class MainActivity : AppCompatActivity() {
     private fun todoRoot(componentContext: ComponentContext): TodoRoot =
         TodoRootComponent(
             componentContext = componentContext,
-            storeFactory = LoggingStoreFactory(TimeTravelStoreFactory(DefaultStoreFactory())),
+            storeFactory = LoggingStoreFactory(TimeTravelStoreFactory()),
             database = DefaultTodoSharedDatabase(TodoDatabaseDriver(context = this))
         )
 }

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -46,7 +46,7 @@ object Deps {
 
     object ArkIvanov {
         object MVIKotlin {
-            private const val VERSION = "3.0.0-alpha01"
+            private const val VERSION = "3.0.0-beta01"
             const val rx = "com.arkivanov.mvikotlin:rx:$VERSION"
             const val mvikotlin = "com.arkivanov.mvikotlin:mvikotlin:$VERSION"
             const val mvikotlinMain = "com.arkivanov.mvikotlin:mvikotlin-main:$VERSION"
@@ -56,9 +56,14 @@ object Deps {
         }
 
         object Decompose {
-            private const val VERSION = "0.3.1"
+            private const val VERSION = "0.5.1"
             const val decompose = "com.arkivanov.decompose:decompose:$VERSION"
             const val extensionsCompose = "com.arkivanov.decompose:extensions-compose-jetbrains:$VERSION"
+        }
+
+        object Essenty {
+            private const val VERSION = "0.2.2"
+            const val lifecycle = "com.arkivanov.essenty:lifecycle:$VERSION"
         }
     }
 

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -11,13 +11,13 @@ kotlin {
         binaries {
             framework {
                 baseName = "Todo"
-                transitiveExport = true
                 linkerOpts.add("-lsqlite3")
                 export(project(":common:database"))
                 export(project(":common:main"))
                 export(project(":common:edit"))
                 export(Deps.ArkIvanov.Decompose.decompose)
                 export(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
+                export(Deps.ArkIvanov.Essenty.lifecycle)
             }
         }
     }
@@ -44,6 +44,7 @@ kotlin {
                 api(project(":common:edit"))
                 api(Deps.ArkIvanov.Decompose.decompose)
                 api(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
+                api(Deps.ArkIvanov.Essenty.lifecycle)
             }
         }
     }

--- a/examples/todoapp/common/root/src/commonMain/kotlin/example/todo/common/root/TodoRoot.kt
+++ b/examples/todoapp/common/root/src/commonMain/kotlin/example/todo/common/root/TodoRoot.kt
@@ -1,6 +1,6 @@
 package example.todo.common.root
 
-import com.arkivanov.decompose.RouterState
+import com.arkivanov.decompose.router.RouterState
 import com.arkivanov.decompose.value.Value
 import example.todo.common.edit.TodoEdit
 import example.todo.common.main.TodoMain

--- a/examples/todoapp/common/root/src/commonMain/kotlin/example/todo/common/root/integration/TodoRootComponent.kt
+++ b/examples/todoapp/common/root/src/commonMain/kotlin/example/todo/common/root/integration/TodoRootComponent.kt
@@ -1,10 +1,10 @@
 package example.todo.common.root.integration
 
 import com.arkivanov.decompose.ComponentContext
-import com.arkivanov.decompose.RouterState
-import com.arkivanov.decompose.pop
-import com.arkivanov.decompose.push
-import com.arkivanov.decompose.router
+import com.arkivanov.decompose.router.RouterState
+import com.arkivanov.decompose.router.pop
+import com.arkivanov.decompose.router.push
+import com.arkivanov.decompose.router.router
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.parcelable.Parcelable
 import com.arkivanov.essenty.parcelable.Parcelize


### PR DESCRIPTION
- Updated Decompose to `0.5.1` and MVIKotlin to `3.0.0-beta01`
- Applied necessary code changes
- Removed `transitiveExport` flag (`ios` target) from the`root` module, because it bloats the framework and causes unnecessary underscores (`_`) in argument names
- Exported the transitive `essenty:lifecycle` dependency explicitly to the iOS framework