### PR TITLE
SplitPane. Remove material dependency

### DIFF
--- a/components/SplitPane/library/build.gradle.kts
+++ b/components/SplitPane/library/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
             dependencies {
                 api(compose.runtime)
                 api(compose.foundation)
-                api(compose.material)
             }
         }
         named("desktopMain") {}

--- a/components/SplitPane/library/src/desktopMain/kotlin/org/jetbrains/compose/splitpane/DesktopSplitPane.kt
+++ b/components/SplitPane/library/src/desktopMain/kotlin/org/jetbrains/compose/splitpane/DesktopSplitPane.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.compose.splitpane
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
@@ -24,10 +25,18 @@ internal actual fun SplitPane(
 ) {
     Layout(
         {
-            first()
-            splitter.measuredPart()
-            second()
-            splitter.handlePart()
+            Box {
+                first()
+            }
+            Box {
+                splitter.measuredPart()
+            }
+            Box {
+                second()
+            }
+            Box {
+                splitter.handlePart()
+            }
         },
         modifier,
     ) { measurables, constraints ->

--- a/components/SplitPane/library/src/desktopMain/kotlin/org/jetbrains/compose/splitpane/DesktopSplitter.kt
+++ b/components/SplitPane/library/src/desktopMain/kotlin/org/jetbrains/compose/splitpane/DesktopSplitter.kt
@@ -1,13 +1,10 @@
 package org.jetbrains.compose.splitpane
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.unit.dp
 import java.awt.Cursor
@@ -15,24 +12,6 @@ import java.awt.Cursor
 @OptIn(ExperimentalComposeUiApi::class)
 private fun Modifier.cursorForHorizontalResize(isHorizontal: Boolean): Modifier =
     pointerHoverIcon(PointerIcon(Cursor(if (isHorizontal) Cursor.E_RESIZE_CURSOR else Cursor.S_RESIZE_CURSOR)))
-
-@Composable
-private fun DesktopSplitPaneSeparator(
-    isHorizontal: Boolean,
-    color: Color = MaterialTheme.colors.background
-) = Box(
-    Modifier
-        .run {
-            if (isHorizontal) {
-                this.width(1.dp)
-                    .fillMaxHeight()
-            } else {
-                this.height(1.dp)
-                    .fillMaxWidth()
-            }
-        }
-        .background(color)
-)
 
 @OptIn(ExperimentalSplitPaneApi::class)
 @Composable
@@ -66,9 +45,7 @@ internal actual fun defaultSplitter(
     isHorizontal: Boolean,
     splitPaneState: SplitPaneState
 ): Splitter = Splitter(
-    measuredPart = {
-        DesktopSplitPaneSeparator(isHorizontal)
-    },
+    measuredPart = {},
     handlePart = {
         DesktopHandle(isHorizontal, splitPaneState)
     }


### PR DESCRIPTION
SplitPane by design shouldn't have default visual representation, because it mostly depends on the design system (material, material3, etc)

Fixes https://github.com/JetBrains/compose-jb/issues/1975

RelNote:
SplitPane no longer depends on compose.material. Now, by default, SplitPane has invisible 0px splitter, not 1px black/white splitter as it was before. If you want to preserve the previous behaviour, specify a splitter explicitly:
```
HorizontalSplitPane(splitterState) {
    splitter {
        visiblePart {
            Box(
                Modifier
                    .height(1.dp)
                    .fillMaxHeight()
                    .background(MaterialTheme.colors.background)
            )
        }
    }
}
```