### PR TITLE
Excluding multiplatform common sources on xcodegen yaml

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
@@ -46,7 +46,12 @@ internal fun Project.configureTaskToGenerateXcodeProject(
                     UILaunchStoryboardName: ""
                     method: "development"
                 sources:
-                  - "../../../src/"
+                  - path: "../../../src/"
+                    excludes:
+                      - "jvm*/**"
+                      - "desktop*/**"
+                      - "android*/**"
+                      - "*Test/**"
                 settings:
                   LIBRARY_SEARCH_PATHS: "$(inherited)"
                   ENABLE_BITCODE: "YES"


### PR DESCRIPTION
When running `./gradlew iosDeployIPhone8Debug` in a module multiplatform that have all platforms in the same place, the task currently fails when other targets (`android` `jvm` `desktop`) have files that is not allowed in a iOS build.

For example: `androidMain/resource` with files `webp` for launcher icon.

Reproduce: https://github.com/adrielcafe/voyager/pull/52