### PR TITLE
Remove unnecessary parameter to required

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
@@ -194,6 +194,14 @@ fun AttrsScope<HTMLInputElement>.placeholder(value: String) =
 fun AttrsScope<HTMLInputElement>.readOnly() =
     attr("readonly", "")
 
+@Deprecated(
+    message = "Please use `required()` without parameters. Use if..else.. if conditional behaviour required.",
+    replaceWith = ReplaceWith("required()", "org.jetbrains.compose.web.attributes.required"),
+    level = DeprecationLevel.WARNING
+)
+fun AttrsScope<HTMLInputElement>.required(value: Boolean = true) =
+    attr("required", value.toString())
+
 fun AttrsScope<HTMLInputElement>.required() =
     attr("required", "")
 

--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/Attrs.kt
@@ -194,8 +194,8 @@ fun AttrsScope<HTMLInputElement>.placeholder(value: String) =
 fun AttrsScope<HTMLInputElement>.readOnly() =
     attr("readonly", "")
 
-fun AttrsScope<HTMLInputElement>.required(value: Boolean = true) =
-    attr("required", value.toString())
+fun AttrsScope<HTMLInputElement>.required() =
+    attr("required", "")
 
 fun AttrsScope<HTMLInputElement>.size(value: Int) =
     attr("size", value.toString())


### PR DESCRIPTION
As [`required` is a boolean attribute](https://html.spec.whatwg.org/multipage/input.html#the-required-attribute), `required(false)` would confusingly make the input required.