### PR TITLE
Fix todoapp sample, iOS build

### DIFF
--- a/examples/todoapp/buildSrc/buildSrc/build.gradle.kts
+++ b/examples/todoapp/buildSrc/buildSrc/build.gradle.kts
@@ -5,3 +5,8 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+dependencies {
+    //todo workaround to build iOS Arm64 simulator:
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
+}

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Env.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Env.kt
@@ -1,6 +1,0 @@
-
-fun isIphoneSimulatorBuild(): Boolean =
-    System.getenv("NATIVE_ARCH") == "arm64" && System.getenv("SDK_NAME")?.startsWith("iphonesimulator") == true
-
-fun isIphoneOsBuild(): Boolean =
-    System.getenv("SDK_NAME")?.startsWith("iphoneos") == true

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/IosWorkaroundSupportArm64Simulator.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/IosWorkaroundSupportArm64Simulator.kt
@@ -1,0 +1,17 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinTargetContainerWithNativeShortcuts
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
+fun KotlinTargetContainerWithNativeShortcuts.iosWorkaroundSupportArm64Simulator(
+    configure: KotlinNativeTarget.() -> Unit
+) {
+    val isBuildToSimulator = System.getenv("SDK_NAME")?.startsWith("iphonesimulator") ?: false
+    val isArm64Target = System.getenv("NATIVE_ARCH") == "arm64"
+
+    if (isBuildToSimulator && isArm64Target) {
+        //workaround:
+        iosSimulatorArm64(name = "ios", configure = configure)
+    } else {
+        //default behavior:
+        ios(configure = configure)
+    }
+}

--- a/examples/todoapp/buildSrc/gradle.properties
+++ b/examples/todoapp/buildSrc/gradle.properties
@@ -1,4 +1,3 @@
 # TODO can we get rid of duplication with root gradle.properties?
-#todo remove -Pkotlin.version=1.6.20 from Xcode project, when stable version on Compose with Koltin 1.6.20 or later released
 kotlin.version=1.6.10
 compose.version=1.1.0

--- a/examples/todoapp/common/database/build.gradle.kts
+++ b/examples/todoapp/common/database/build.gradle.kts
@@ -13,12 +13,6 @@ sqldelight {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
 
     iosTarget("ios") {
     }

--- a/examples/todoapp/common/database/build.gradle.kts
+++ b/examples/todoapp/common/database/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")
@@ -13,16 +11,7 @@ sqldelight {
 }
 
 kotlin {
-
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
+    iosWorkaroundSupportArm64Simulator {}
 
     sourceSets {
         commonMain {

--- a/examples/todoapp/common/database/build.gradle.kts
+++ b/examples/todoapp/common/database/build.gradle.kts
@@ -14,6 +14,13 @@ sqldelight {
 
 kotlin {
 
+    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
+        when {
+            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
+            isIphoneOsBuild() -> ::iosArm64
+            else -> ::iosX64
+        }
+
     iosTarget("ios") {
     }
 

--- a/examples/todoapp/common/edit/build.gradle.kts
+++ b/examples/todoapp/common/edit/build.gradle.kts
@@ -1,20 +1,10 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
+    iosWorkaroundSupportArm64Simulator {}
 
     sourceSets {
         named("commonMain") {

--- a/examples/todoapp/common/main/build.gradle.kts
+++ b/examples/todoapp/common/main/build.gradle.kts
@@ -1,20 +1,10 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
+    iosWorkaroundSupportArm64Simulator {}
 
     sourceSets {
         named("commonMain") {

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")
@@ -7,14 +5,7 @@ plugins {
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
+    iosWorkaroundSupportArm64Simulator {
         binaries {
             framework {
                 baseName = "Todo"

--- a/examples/todoapp/common/root/build.gradle.kts
+++ b/examples/todoapp/common/root/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     ios {
         binaries {
             framework {
-                baseName = "KotlinCommon"
+                baseName = "Todo"
                 linkerOpts.add("-lsqlite3")
                 export(project(":common:database"))
                 export(project(":common:main"))

--- a/examples/todoapp/common/utils/build.gradle.kts
+++ b/examples/todoapp/common/utils/build.gradle.kts
@@ -6,12 +6,6 @@ plugins {
 }
 
 kotlin {
-    fun isIphoneSimulatorBuild(): Boolean =
-        System.getenv("NATIVE_ARCH") == "arm64" && System.getenv("SDK_NAME")?.startsWith("iphonesimulator") == true
-
-    fun isIphoneOsBuild(): Boolean =
-        System.getenv("SDK_NAME")?.startsWith("iphoneos") == true
-
     val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
         when {
             isIphoneSimulatorBuild() -> ::iosSimulatorArm64

--- a/examples/todoapp/common/utils/build.gradle.kts
+++ b/examples/todoapp/common/utils/build.gradle.kts
@@ -1,20 +1,10 @@
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-
 plugins {
     id("multiplatform-setup")
     id("android-setup")
 }
 
 kotlin {
-    val iosTarget: (String, KotlinNativeTarget.() -> Unit) -> KotlinNativeTarget =
-        when {
-            isIphoneSimulatorBuild() -> ::iosSimulatorArm64
-            isIphoneOsBuild() -> ::iosArm64
-            else -> ::iosX64
-        }
-
-    iosTarget("ios") {
-    }
+    iosWorkaroundSupportArm64Simulator {}
 
     sourceSets {
         named("commonMain") {

--- a/examples/todoapp/gradle.properties
+++ b/examples/todoapp/gradle.properties
@@ -23,6 +23,5 @@ org.gradle.parallel=true
 org.gradle.caching=true
 kotlin.native.disableCompilerDaemon=true
 
-#todo remove -Pkotlin.version=1.6.20 from Xcode project, when stable version on Compose with Koltin 1.6.20 or later released
 kotlin.version=1.6.10
 compose.version=1.1.0

--- a/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
+++ b/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		1F00F390257599DA00CFAF97 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1F00F393257599DA00CFAF97 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1F00F395257599DA00CFAF97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		1F00F3A325759FEC00CFAF97 /* KotlinCommon.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = KotlinCommon.framework; path = "../common/root/build/xcode-frameworks/KotlinCommon.framework"; sourceTree = "<group>"; };
+		1F00F3A325759FEC00CFAF97 /* Todo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Todo.framework; path = "../common/root/build/xcode-frameworks/Todo.framework"; sourceTree = "<group>"; };
 		1F00F3A72575A16400CFAF97 /* ObservableValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableValue.swift; sourceTree = "<group>"; };
 		1F00F3A92575A71000CFAF97 /* MutableStateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutableStateBuilder.swift; sourceTree = "<group>"; };
 		1F00F3AB2575AA4500CFAF97 /* ListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListView.swift; sourceTree = "<group>"; };
@@ -101,7 +101,7 @@
 		1F00F3A225759FEC00CFAF97 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				1F00F3A325759FEC00CFAF97 /* KotlinCommon.framework */,
+				1F00F3A325759FEC00CFAF97 /* Todo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -188,7 +188,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode -Pkotlin.version=1.6.20\n";
+			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode -Pkotlin.version=1.6.20";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
+++ b/examples/todoapp/ios/TodoApp.xcodeproj/project.pbxproj
@@ -171,7 +171,6 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* TODO Remove workaround -Pkotlin.version=1.6.20, when newer version of Compose released */
 /* Begin PBXShellScriptBuildPhase section */
 		1F00F39D25759BB300CFAF97 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -188,7 +187,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode -Pkotlin.version=1.6.20";
+			shellScript = "cd $SRCROOT/..\n./gradlew :common:root:embedAndSignAppleFrameworkForXcode";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Build was broken.

To fix it:
1) We revert framework name KotlinCommon -> Todo 
2) And check if Xcode works on Arm64 CPU and build on simulator -> then use workaround.

How to check:
 - `git clone --depth 1  --branch dima_avdeev/fix_todoapp_ios https://github.com/JetBrains/compose-jb.git /tmp/compose-jb`
 - `open /tmp/compose-jb/examples/todoapp/ios/TodoApp.xcodeproj/` (Xcode will opens)
 - Choose iOS Simulator, Run project