### PR TITLE
update experimental samples compose (1.2.0-alpha01-dev675) and kotlin version (1.6.21)

### DIFF
--- a/experimental/examples/falling-balls-mpp/build.gradle.kts
+++ b/experimental/examples/falling-balls-mpp/build.gradle.kts
@@ -163,9 +163,6 @@ compose.experimental {
                 //Usage: ./gradlew iosDeployIPadDebug
                 device = IOSDevices.IPAD_MINI_6th_Gen
             }
-            connectedDevice("Device") {
-                //Usage: ./gradlew iosDeployDeviceRelease
-            }
         }
     }
 }

--- a/experimental/examples/falling-balls-mpp/gradle.properties
+++ b/experimental/examples/falling-balls-mpp/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx3g
-compose.version=1.2.0-alpha01-dev620
+compose.version=1.2.0-alpha01-dev675
 kotlin.version=1.6.10
 kotlin.code.style=official
 kotlin.native.cacheKind=none

--- a/experimental/examples/falling-balls-mpp/gradle.properties
+++ b/experimental/examples/falling-balls-mpp/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx3g
 compose.version=1.2.0-alpha01-dev675
-kotlin.version=1.6.10
+kotlin.version=1.6.21
 kotlin.code.style=official
 kotlin.native.cacheKind=none
 kotlin.native.useEmbeddableCompilerJar=true

--- a/experimental/examples/falling-balls-mpp/gradle/wrapper/gradle-wrapper.properties
+++ b/experimental/examples/falling-balls-mpp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/experimental/examples/minesweeper/build.gradle.kts
+++ b/experimental/examples/minesweeper/build.gradle.kts
@@ -16,7 +16,7 @@ buildscript {
 
 plugins {
     kotlin("multiplatform") version "1.6.10"
-    id("org.jetbrains.compose") version "1.2.0-alpha01-dev620"
+    id("org.jetbrains.compose") version "1.2.0-alpha01-dev675"
 }
 
 version = "1.0-SNAPSHOT"
@@ -164,9 +164,9 @@ compose.experimental {
                 //Usage: ./gradlew iosDeployIPadDebug
                 device = IOSDevices.IPAD_MINI_6th_Gen
             }
-            connectedDevice("Device") {
+//            connectedDevice("Device") { //todo lazy init (compose.ios.teamId=*** in local.properties)
                 //Usage: ./gradlew iosDeployDeviceRelease
-            }
+//            }
         }
     }
 }

--- a/experimental/examples/minesweeper/build.gradle.kts
+++ b/experimental/examples/minesweeper/build.gradle.kts
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.6.10"
+    kotlin("multiplatform") version "1.6.21"
     id("org.jetbrains.compose") version "1.2.0-alpha01-dev675"
 }
 

--- a/experimental/examples/minesweeper/gradle/wrapper/gradle-wrapper.properties
+++ b/experimental/examples/minesweeper/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
After this changes you can run iOS targets (without mavenLocal)