### PR TITLE
COMPILE_SDK_VERSION = android-32

### DIFF
--- a/compose/scripts/downloadAndroidSdk
+++ b/compose/scripts/downloadAndroidSdk
@@ -15,8 +15,8 @@ clone() {
 # Commit hashes and sdk versions from https://android.googlesource.com/platform/manifest/+/refs/heads/androidx-main/default.xml
 
 downloadLinuxSDK() {
-    clone ../prebuilts/fullsdk-linux/platforms/android-31 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-31 master
-    clone ../prebuilts/fullsdk-linux/sources/android-31 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-31 master
+    clone ../prebuilts/fullsdk-linux/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
+    clone ../prebuilts/fullsdk-linux/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
     clone ../prebuilts/fullsdk-linux/ndk https://android.googlesource.com/toolchain/prebuilts/ndk/r23 master
     clone ../prebuilts/fullsdk-linux/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-linux/build-tools/30.0.3 master
     clone ../prebuilts/fullsdk-linux/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-linux/platform-tools master
@@ -26,8 +26,8 @@ downloadLinuxSDK() {
 }
 
 downloadMacOsSDK() {
-    clone ../prebuilts/fullsdk-darwin/platforms/android-31 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-31 master
-    clone ../prebuilts/fullsdk-darwin/sources/android-31 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-31 master
+    clone ../prebuilts/fullsdk-darwin/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
+    clone ../prebuilts/fullsdk-darwin/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
     clone ../prebuilts/fullsdk-darwin/ndk https://android.googlesource.com/toolchain/prebuilts/ndk-darwin/r23 master
     clone ../prebuilts/fullsdk-darwin/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/build-tools/30.0.3 master
     clone ../prebuilts/fullsdk-darwin/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/platform-tools master


### PR DESCRIPTION
Update downloadAndroidSdk script to version of sdk=android-32

## For contributors:
 - You need to remove old android sdk (on Mac it's is located at compose/prebuilts/fullsdk-darwin)
 - And run ./scripts/downloadAndroidSdk 