### PR TITLE
Remove deprecated `useIR` option

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -128,7 +128,6 @@ class ComposePlugin : Plugin<Project> {
                     if (overrideDefaultJvmTarget) {
                         jvmTarget = "11".takeIf { jvmTarget.toDouble() < 11 } ?: jvmTarget
                     }
-                    useIR = true
                 }
             }
         }


### PR DESCRIPTION
Fixes #2075 

Option is already true by default and was removed in Kotlin 1.7.

Removed it in the Compose code so it no longer throws a `java.lang.NoSuchMethodError`.