### PR TITLE
describe scripts to run tests and samples

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -81,7 +81,7 @@ Run jvm desktop sample:
 ```
 another jvm desktop samples: 
 ```bash
-./scripts/runGradle run1 run2 run3 run4
+./scripts/runGradle run1 run2 run3 run4 runWindowApi runVsync
 ```
 
 Run wasm sample:

--- a/compose/README.md
+++ b/compose/README.md
@@ -3,11 +3,11 @@
 Composite build of [Compose-jb sources](https://github.com/JetBrains/androidx)
 
 ## Download submodules after downloading the main project:
-```
+```bash
 git submodule update --init --recursive
 ```
 Set this property to always update submodules on git checkout/pull/reset:
-```
+```bash
 git config --global submodule.recurse true
 ```
 
@@ -50,18 +50,48 @@ export COMPOSE_CUSTOM_VERSION=0.0.0-custom
 (on Windows it doesn't build at the moment, the issue is in the line `packageInspector(project, project(":compose:ui:ui-inspection")` in `compose/frameworks/support/compose/ui/ui/build.gradle`)
 
 Publish extended icons:
-```
+```bash
 ./scripts/publishExtendedIcons
 ```
 
+### Run tests
+
 Run tests for Desktop:
-```
+```bash
 ./scripts/testDesktop
 ```
 
 Run tests for Web:
-```
+```bash
 ./scripts/testWeb
+```
+
+Run tests for Android:
+```bash
+./scripts/testAndroidUnit.sh
+```
+```bash
+./scripts/testAndroidInEmulator.sh # first run android simulator or connect device
+```
+
+### Run samples
+Run jvm desktop sample:
+```bash
+./scripts/runGradle run
+```
+another jvm desktop samples: 
+```bash
+./scripts/runGradle run1 run2 run3 run4
+```
+
+Run wasm sample:
+```bash
+./scripts/runGradle runMppJs
+```
+
+Run native macos sample:
+```bash
+./scripts/runGradle runMppMacos
 ```
 
 ## Multiplatform build

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -156,6 +156,14 @@ tasks.register("run") {
     dependsOnComposeTask(":compose:desktop:desktop:desktop-samples:run")
 }
 
+tasks.register("runMppJs") {
+    dependsOnComposeTask(":compose:mpp:demo:jsRun")
+}
+
+tasks.register("runMppNative") {
+    dependsOnComposeTask(":compose:mpp:demo:runDebugExecutable")
+}
+
 val mavenCentral = MavenCentralProperties(project)
 if (mavenCentral.signArtifacts) {
     signing.useInMemoryPgpKeys(

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -162,6 +162,14 @@ for (i in 1..4) {
     }
 }
 
+tasks.register("runWindowApi") {
+    dependsOnComposeTask(":compose:desktop:desktop:desktop-samples:runWindowApi")
+}
+
+tasks.register("runVsync") {
+    dependsOnComposeTask(":compose:desktop:desktop:desktop-samples:runVsync")
+}
+
 tasks.register("runMppJs") {
     dependsOnComposeTask(":compose:mpp:demo:jsRun")
 }

--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -156,12 +156,18 @@ tasks.register("run") {
     dependsOnComposeTask(":compose:desktop:desktop:desktop-samples:run")
 }
 
+for (i in 1..4) {
+    tasks.register("run$i") {
+        dependsOnComposeTask(":compose:desktop:desktop:desktop-samples:run$i")
+    }
+}
+
 tasks.register("runMppJs") {
     dependsOnComposeTask(":compose:mpp:demo:jsRun")
 }
 
-tasks.register("runMppNative") {
-    dependsOnComposeTask(":compose:mpp:demo:runDebugExecutable")
+tasks.register("runMppMacos") {
+    dependsOnComposeTask(":compose:mpp:demo:runDebugExecutableMacosX64")
 }
 
 val mavenCentral = MavenCentralProperties(project)


### PR DESCRIPTION
Describe how to run samples in compose/README.md.
add gradle tasks to run js (wasm) and native macos samples.

Scripts lines in README.md are clickable:
<img width="237" alt="image" src="https://user-images.githubusercontent.com/99798741/171244708-df2f229b-3186-4c8f-a490-e628268a7be3.png">
