### PR TITLE
Web: Support attrs extension functions in sub elements too

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/attributes/AttrsScope.kt
@@ -28,7 +28,7 @@ typealias AttrsBuilder<T> = AttrsScopeBuilder<T>
  *
  */
 @HtmlAttrMarker
-interface AttrsScope<TElement : Element> : EventsListenerScope {
+interface AttrsScope<out TElement : Element> : EventsListenerScope {
     /**
      * [style] add inline CSS-style properties to the element via [StyleScope] context
      *


### PR DESCRIPTION
Eg SvgRectElement extends SvgElement, but `width` is defined in `AttrsScope<SvgElement>` which is not usable in SvgRectElement attrs builder because the element types don't match.