### PR TITLE
Add missing `background-blend-mode` property

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/background.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/background.kt
@@ -48,3 +48,8 @@ fun StyleScope.background(value: String) {
     property("background", value)
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/background-blend-mode
+fun StyleScope.backgroundBlendMode(value: String) {
+    property("background-blend-mode", value)
+}
+


### PR DESCRIPTION
This PR adds `StyleScope.backgroundBlendMode` to `background.kt`