### PR TITLE
Workaround for empty jvmTarget

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -126,7 +126,9 @@ class ComposePlugin : Plugin<Project> {
             project.tasks.withType(KotlinCompile::class.java) {
                 it.kotlinOptions.apply {
                     if (overrideDefaultJvmTarget) {
-                        jvmTarget = "11".takeIf { jvmTarget.toDouble() < 11 } ?: jvmTarget
+                        if (jvmTarget.isBlank() || jvmTarget.toDouble() < 11) {
+                            jvmTarget = "11"
+                        }
                     }
                 }
             }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -126,7 +126,7 @@ class ComposePlugin : Plugin<Project> {
             project.tasks.withType(KotlinCompile::class.java) {
                 it.kotlinOptions.apply {
                     if (overrideDefaultJvmTarget) {
-                        if (jvmTarget.isBlank() || jvmTarget.toDouble() < 11) {
+                        if (jvmTarget.isNullOrBlank() || jvmTarget.toDouble() < 11) {
                             jvmTarget = "11"
                         }
                     }


### PR DESCRIPTION
With Kotlin 1.7 `jvmTarget` is null (or blank) by default if not set explicit, so `toDouble` throws an NPE during project configuration with a jvm target.
https://youtrack.jetbrains.com/issue/KT-52857