### PR TITLE
Fix compose gradle plugin, lazy initialization of teamId for iOS deploy

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/configureTaskToGenerateXcodeProject.kt
@@ -13,7 +13,7 @@ internal fun Project.configureTaskToGenerateXcodeProject(
     id: String,
     projectName: String,
     bundleIdPrefix: String,
-    teamId: String? = null,
+    getTeamId: () -> String? = { null },
     taskInstallXcodeGen: TaskProvider<*>,
 ): TaskProvider<AbstractComposeIosTask> = tasks.composeIosTask<AbstractComposeIosTask>("iosGenerateXcodeProject$id") {
     dependsOn(taskInstallXcodeGen)
@@ -26,7 +26,7 @@ internal fun Project.configureTaskToGenerateXcodeProject(
             options:
               bundleIdPrefix: $bundleIdPrefix
             settings:
-              ${if (teamId != null) "DEVELOPMENT_TEAM: \"$teamId\"" else ""}
+              ${if (getTeamId() != null) "DEVELOPMENT_TEAM: \"${getTeamId()}\"" else ""}
               CODE_SIGN_IDENTITY: "iPhone Developer"
               CODE_SIGN_STYLE: Automatic
               MARKETING_VERSION: "1.0"

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/registerConnectedDeviceTasks.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/uikit/internal/registerConnectedDeviceTasks.kt
@@ -28,15 +28,17 @@ fun Project.registerConnectedDeviceTasks(
         id = id,
         projectName = projectName,
         bundleIdPrefix = bundleIdPrefix,
-        teamId = deploy.teamId ?: getLocalProperty(TEAM_ID_PROPERTY_KEY)
-        ?: error(
-            buildString {
-                appendLine("In local.properties (${localPropertiesFile.absolutePath})")
-                appendLine("Add property")
-                appendLine("$TEAM_ID_PROPERTY_KEY=***")
-                appendLine("Or set teamId in deploy with id: $id")
-            }
-        ),
+        getTeamId = {
+            deploy.teamId ?: getLocalProperty(TEAM_ID_PROPERTY_KEY)
+            ?: error(
+                buildString {
+                    appendLine("In local.properties (${localPropertiesFile.absolutePath})")
+                    appendLine("Add property")
+                    appendLine("$TEAM_ID_PROPERTY_KEY=***")
+                    appendLine("Or set teamId in deploy with id: $id")
+                }
+            )
+        },
         taskInstallXcodeGen = taskInstallXcodeGen,
     )
 


### PR DESCRIPTION
Bug occurs: if teamId not present - can't deploy to simulator target.
Now, made teamId lazy initialized.