### PR TITLE
Fix CI: Add yarn lock file

### DIFF
--- a/gradle-plugins/compose/build.gradle.kts
+++ b/gradle-plugins/compose/build.gradle.kts
@@ -91,7 +91,8 @@ val jar = tasks.named<Jar>("jar") {
 }
 
 // __SUPPORTED_GRADLE_VERSIONS__
-testGradleVersion("6.4")
+//testGradleVersion("6.7.1") // min supported by kotlin 1.7.0 gradle plugin https://kotlinlang.org/docs/gradle.html
+// despite that, some tests didn't pass
 testGradleVersion("7.1.1")
 testGradleVersion("7.3.3")
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -126,7 +126,9 @@ class ComposePlugin : Plugin<Project> {
             project.tasks.withType(KotlinCompile::class.java) {
                 it.kotlinOptions.apply {
                     if (overrideDefaultJvmTarget) {
-                        jvmTarget = "11".takeIf { jvmTarget.toDouble() < 11 } ?: jvmTarget
+                        if (jvmTarget.isNullOrBlank() || jvmTarget.toDouble() < 11) {
+                            jvmTarget = "11"
+                        }
                     }
                 }
             }

--- a/web/buildSrc/src/main/kotlin/SeleniumDriverPlugin.kt
+++ b/web/buildSrc/src/main/kotlin/SeleniumDriverPlugin.kt
@@ -4,8 +4,8 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import java.io.File
 import java.net.URL
 
-private val CHROME_DRIVER_VERSION = "98.0.4758.48"
-private val GECKO_DRIVER_VERSION = "0.30.0"
+private val CHROME_DRIVER_VERSION = "102.0.5005.61"
+private val GECKO_DRIVER_VERSION = "0.31.0"
 
 private fun download(url: String, file: File) {
     println("downloading ${url} to ${file}")

--- a/web/widgets/src/jsMain/kotlin/layouts/text.kt
+++ b/web/widgets/src/jsMain/kotlin/layouts/text.kt
@@ -33,6 +33,7 @@ internal actual fun TextActual(
                 when (size.unitType) {
                     TextUnitType.Em -> fontSize(size.value.em)
                     TextUnitType.Sp -> fontSize(size.value.px)
+                    else -> fontSize(size.value.px)
                 }
             }
 


### PR DESCRIPTION
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_Subtasks_1ComposePublishNativeOptional/3887770?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true failed, because it tries to fetch @types-eslint 8.4.4 which is indeed not available: https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.4.tgz

Added a working lock file to prevent build failures due to dynamic dependencies.