### PR TITLE
Gradle Plugin: Fix NPE and use 1.8 by default

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -126,7 +126,9 @@ class ComposePlugin : Plugin<Project> {
             project.tasks.withType(KotlinCompile::class.java) {
                 it.kotlinOptions.apply {
                     if (overrideDefaultJvmTarget) {
-                        jvmTarget = "11".takeIf { jvmTarget.toDouble() < 11 } ?: jvmTarget
+                        if (jvmTarget.isNullOrBlank() || jvmTarget.toDouble() < 1.8) {
+                             jvmTarget = "1.8"
+                         }
                     }
                 }
             }


### PR DESCRIPTION
At the moment, the [740 build failed](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/3890160?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&expandBuildTestsSection=true) because with Kotlin 1.7 jvmTarget is null (or blank) by default if not set explicit, so toDouble throws an NPE during project configuration with a jvm target.
https://youtrack.jetbrains.com/issue/KT-52857

Based on https://github.com/JetBrains/compose-jb/issues/2112#issuecomment-1159521628 I set the jvmTarget to 1.8