### PR TITLE
Correct information about releases in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Preview functionality (check your application UI without building/running it) fo
        
 ## Getting latest version of Compose Multiplatform ##
 
-See https://github.com/JetBrains/compose-jb/tags for the latest build number.
+See https://github.com/JetBrains/compose-jb/releases/latest for the latest stable release or https://github.com/JetBrains/compose-jb/releases for all stable and dev releases.


### PR DESCRIPTION
The current link leads to the list of dev releases, and can confuse people if they want to find the latest stable, not the latest dev release.

The alternative is to remove this section and keep only "default" places to show the current releases:
![image](https://user-images.githubusercontent.com/5963351/178287359-5598b3d8-cbef-43e4-82ef-15bbd6f6e0f5.png)

But probably it is better to write about dev releases explicitly.
