### PR TITLE
Add pom information and license to Web artifacts

### DIFF
--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -78,7 +78,7 @@ subprojects {
                     url.set("https://www.jetbrains.com/lp/compose-mpp/")
                     licenses {
                         license {
-                            name.set("The Apache License, Version 2.0")
+                            name.set("Apache-2.0")
                             url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
                         }
                     }

--- a/web/build.gradle.kts
+++ b/web/build.gradle.kts
@@ -70,6 +70,33 @@ subprojects {
                     }
                 }
             }
+            publications.all {
+                this as MavenPublication
+                pom {
+                    name.set("JetBrains Compose Multiplatform")
+                    description.set("JetBrains Compose Multiplatform for Web")
+                    url.set("https://www.jetbrains.com/lp/compose-mpp/")
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("JetBrains")
+                            name.set("JetBrains Compose Team")
+                            organization.set("JetBrains")
+                            organizationUrl.set("https://www.jetbrains.com")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git://github.com/JetBrains/compose-jb.git")
+                        developerConnection.set("scm:git://github.com/JetBrains/compose-jb.git")
+                        url.set("https://github.com/jetbrains/compose-jb")
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The web artifact has no pom information and no license: https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/web/web-core/1.2.0-alpha01-dev748/web-core-1.2.0-alpha01-dev748.pom
The information are useful for automatic license scanning tools.