### PR TITLE
Restructure the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Compose Multiplatform uses Jetpack Compose developed by Google when you target A
 
 [The docs](https://developer.android.com/jetpack/compose/documentation) published by Google are great and decribe how to develop on Compose for Android.
 
-Note that when you use Compose Multiplatform, you setup your project differently. You can create a multiplatform project with Android support via IDEA Project Wizard, or copying [multiplatform template](https://github.com/JetBrains/compose-jb/tree/master/templates/multiplatform-template). In `androidMain` source set you can use almost all information from the docs, and in `commonMain` source set you can use information from Foundation and Design sections.
+Note that when you use Compose Multiplatform, you setup your project differently. You can create a multiplatform project with Android support via IDEA Project Wizard, or by copying [multiplatform template](https://github.com/JetBrains/compose-jb/tree/master/templates/multiplatform-template). In `androidMain` source set you can use almost all information from the docs, and in `commonMain` source set you can use information from Foundation and Design sections.
 
 ## Examples
    * [codeviewer](examples/codeviewer) - File Browser and Code Viewer application for Android and Desktop

--- a/README.md
+++ b/README.md
@@ -9,56 +9,67 @@ at https://android.googlesource.com/platform/frameworks/support.
 
 Preview functionality (check your application UI without building/running it) for desktop platforms is available via IDEA plugin (https://plugins.jetbrains.com/plugin/16541-compose-multiplatform-ide-support).
 
-## Repository organization ##
+## Tutorials
+### Compose for Desktop
+* [Getting started](tutorials/Getting_Started)
+* [Image and icon manipulations](tutorials/Image_And_Icons_Manipulations)
+* [Mouse events and hover](tutorials/Mouse_Events)
+* [Scrolling and scrollbars](tutorials/Desktop_Components#scrollbars)
+* [Tooltips](tutorials/Desktop_Components#tooltips)
+* [Top level windows management](tutorials/Window_API_new)
+* [Menu, tray, notifications](tutorials/Tray_Notifications_MenuBar_new)
+* [Keyboard support](tutorials/Keyboard)
+* [Tab focus navigation](tutorials/Tab_Navigation)
+* [Swing interoperability](tutorials/Swing_Integration)
+* [Navigation](tutorials/Navigation)
+* [Accessibility](https://github.com/JetBrains/compose-jb/tree/master/tutorials/Accessibility)
+* [Building native distribution](tutorials/Native_distributions_and_local_execution)
+* [Signing and notarization](tutorials/Signing_and_notarization_on_macOS)
 
-   * [artwork](artwork) - design artifacts
-   * [benchmarks](benchmarks) - collection of benchmarks
-   * [compose](compose) - composite build of [Compose-jb sources](https://github.com/JetBrains/androidx)
-   * [ci](ci) - Continuous Integration helpers
-   * [examples](examples) - examples of multiplatform Compose applications for Desktop, Android and Web
-       * [codeviewer](examples/codeviewer) - File Browser and Code Viewer application for Android and Desktop
-       * [imageviewer](examples/imageviewer) - Image Viewer application for Android and Desktop
-       * [issues](examples/issues) - GitHub issue tracker with an adaptive UI and ktor-client
-       * [game](examples/falling-balls) - Simple game
-       * [game](experimental/examples/falling-balls-mpp) - Simple game for web target
-       * [compose-bird](examples/web-compose-bird) - A flappy bird clone using Compose for Web
-       * [notepad](examples/notepad) - Notepad, using the new experimental Composable Window API
-       * [todoapp](examples/todoapp) - TODO items tracker with persistence and multiple screens
-       * [todoapp-lite](examples/todoapp-lite) - A simplified version of [todoapp](examples/todoapp), fully based on Compose
-       * [widgets gallery](examples/widgets-gallery) - Gallery of standard widgets
-       * [IDEA plugin](examples/intellij-plugin) - Plugin for IDEA using Compose for Desktop
-   * [gradle-plugins](gradle-plugins) - a plugin, simplifying usage of Compose Multiplatform with Gradle
-   * [templates](templates) - new application templates
-   * [tutorials](tutorials) - tutorials on using Compose Multiplatform
-       * [Getting started](tutorials/Getting_Started)
-       * [Image and icon manipulations](tutorials/Image_And_Icons_Manipulations)
-       * [Mouse events and hover](tutorials/Mouse_Events)
-       * [Scrolling and scrollbars](tutorials/Desktop_Components#scrollbars)
-       * [Tooltips](tutorials/Desktop_Components#tooltips)
-       * [Top level windows management](tutorials/Window_API_new)
-       * [Menu, tray, notifications](tutorials/Tray_Notifications_MenuBar_new)
-       * [Keyboard support](tutorials/Keyboard)
-       * [Tab focus navigation](tutorials/Tab_Navigation)
-       * [Swing interoperability](tutorials/Swing_Integration)
-       * [Development for Android](tutorials/Development_for_Android)
-       * [Navigation](tutorials/Navigation)
-       * [Accessibility](https://github.com/JetBrains/compose-jb/tree/master/tutorials/Accessibility)
-       * [Building native distribution](tutorials/Native_distributions_and_local_execution)
-       * [Signing and notarization](tutorials/Signing_and_notarization_on_macOS)
-   * [tutorials: compose for web](tutorials/Web) - tutorials on using Compose for Web
-       * [Getting started with Compose for Web](tutorials/Web/Getting_Started) 
-       * [Building web UI](tutorials/Web/Building_UI)
-       * [Handling Events](tutorials/Web/Events_Handling)
-       * [Controlled and Uncontrolled inputs](tutorials/Web/Controlled_Uncontrolled_Inputs)
-       * [Style DSL](tutorials/Web/Style_Dsl)
-       * [Using test-utils](tutorials/Web/Using_Test_Utils)
-   * [components](components) - custom components of Compose Multiplatform
-       * [Split Pane](components/SplitPane)
-   * [experimental](experimental) - experimental components and examples
-       * [cef](experimental/cef) - CEF integration in Jetpack Compose (somewhat outdated)
-       * [Video Player](experimental/components/VideoPlayer)
-       * [LWJGL integration](experimental/lwjgl-integration) - An example showing how to integrate Compose with [LWJGL](https://www.lwjgl.org)
-       * [CLI example](experimental/build_from_cli) - An example showing how to build Compose without Gradle
+Also, see [Foundation](https://developer.android.com/jetpack/compose/documentation#core) and [Design](https://developer.android.com/jetpack/compose/documentation#design) docs from Google. They were originally written for Android, but most of information applies to Compose for Desktop as well.
+
+### Compose for Web
+* [Getting started with Compose for Web](tutorials/Web/Getting_Started) 
+* [Building web UI](tutorials/Web/Building_UI)
+* [Handling Events](tutorials/Web/Events_Handling)
+* [Controlled and Uncontrolled inputs](tutorials/Web/Controlled_Uncontrolled_Inputs)
+* [Style DSL](tutorials/Web/Style_Dsl)
+* [Using test-utils](tutorials/Web/Using_Test_Utils)
+
+### Jetpack Compose for Android
+Compose Multiplatform uses Jetpack Compose developed by Google when you target Android platform. See more info about it [here](tutorials/Development_for_Android).
+
+[The docs](https://developer.android.com/jetpack/compose/documentation) published by Google are great and decribe how to develop on Compose for Android.
+
+Note that when you use Compose Multiplatform, you setup your project differently. You can create a multiplatform project with Android support via IDEA Project Wizard, or copying [multiplatform template](https://github.com/JetBrains/compose-jb/tree/master/templates/multiplatform-template). In `androidMain` source set you can use almost all information from the docs, and in `commonMain` source set you can use information from Foundation and Design sections.
+
+## Examples
+   * [codeviewer](examples/codeviewer) - File Browser and Code Viewer application for Android and Desktop
+   * [imageviewer](examples/imageviewer) - Image Viewer application for Android and Desktop
+   * [issues](examples/issues) - GitHub issue tracker with an adaptive UI and ktor-client
+   * [game](examples/falling-balls) - Simple game
+   * [game](experimental/examples/falling-balls-mpp) - Simple game for web target
+   * [compose-bird](examples/web-compose-bird) - A flappy bird clone using Compose for Web
+   * [notepad](examples/notepad) - Notepad, using the new experimental Composable Window API
+   * [todoapp](examples/todoapp) - TODO items tracker with persistence and multiple screens
+   * [todoapp-lite](examples/todoapp-lite) - A simplified version of [todoapp](examples/todoapp), fully based on Compose
+   * [widgets gallery](examples/widgets-gallery) - Gallery of standard widgets
+   * [IDEA plugin](examples/intellij-plugin) - Plugin for IDEA using Compose for Desktop
+
+## Other ##
+* [artwork](artwork) - design artifacts
+* [benchmarks](benchmarks) - collection of benchmarks
+* [compose](compose) - composite build of [Compose-jb sources](https://github.com/JetBrains/androidx)
+* [ci](ci) - Continuous Integration helpers
+* [gradle-plugins](gradle-plugins) - a plugin, simplifying usage of Compose Multiplatform with Gradle
+* [templates](templates) - new application templates
+* [components](components) - custom components of Compose Multiplatform
+   * [Split Pane](components/SplitPane)
+* [experimental](experimental) - experimental components and examples
+   * [cef](experimental/cef) - CEF integration in Jetpack Compose (somewhat outdated)
+   * [Video Player](experimental/components/VideoPlayer)
+   * [LWJGL integration](experimental/lwjgl-integration) - An example showing how to integrate Compose with [LWJGL](https://www.lwjgl.org)
+   * [CLI example](experimental/build_from_cli) - An example showing how to build Compose without Gradle
        
 ## Getting latest version of Compose Multiplatform ##
 


### PR DESCRIPTION
Extract tutorials and examples to separate sections. 

Also add links to Android documentation. This documentation is very comprehensive comparing to our current documentation, that covers mainly desktop aspects.

Until we write our own docs, or unify Jetpack Compose docs with Google collaboration, it is better to have links to this documentation than not to have it.

See also https://github.com/JetBrains/compose-jb/pull/2250