### PR TITLE
Simplify js condition

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -54,7 +54,7 @@ class ComposePlugin : Plugin<Project> {
         project.afterEvaluate {
             configureDesktop(project, desktopExtension)
             project.configureExperimental(composeExtension, experimentalExtension)
-            project.checkExperimentalTargetsWithSkikoIsEnabled()
+            project.checkExperimentalTargetsWithSkikoIsEnabled(experimentalExtension)
 
             if (androidExtension.useAndroidX) {
                 project.logger.warn("useAndroidX is an experimental feature at the moment!")


### PR DESCRIPTION
I found, that previous check fails on stable JS projects. Because skiko dependency exist's also in stable JS build. 

I found, that it's simpler to check only experimental extension for JS target:
```
    compose.experimental {
    web.application {}

```
Fixed.