### PR TITLE
Fix demo run, add gradle.properties

### DIFF
--- a/compose/gradle.properties
+++ b/compose/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true


### PR DESCRIPTION
Fix demo project's run. Right from README.md:

Run jvm desktop sample:
```bash
./scripts/runGradle run
```
another jvm desktop samples: 
```bash
./scripts/runGradle run1 run2 run3 run4 runWindowApi runVsync runLayout
```

Run wasm sample:
```bash
./scripts/runGradle runMppJs
```

Run native macos sample:
```bash
./scripts/runGradle runMppMacos
```

add more memory to gradle.properties