### PR TITLE
Temporary deprecate 3 overloads of StyleScope.borderWidth

### DIFF
--- a/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/border.kt
+++ b/web/core/src/jsMain/kotlin/org/jetbrains/compose/web/css/properties/border.kt
@@ -83,26 +83,115 @@ fun StyleScope.borderWidth(width: CSSNumeric) {
     property("border-width", width)
 }
 
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/border-width
+ *
+ * First argument sets the vertical borders width.
+ * Second argument sets the horizontal borders width.
+ *
+ * NOTE: Temporary deprecation until 2.0 because of wrong parameters names.
+ * In 2.0 the parameter names should be fixed. Despite the wrong parameter names, the function behaves correctly.
+ */
+@Deprecated(
+    message = "This function has misleading parameter names. " +
+            "Despite that, it behaves correctly (see https://developer.mozilla.org/en-US/docs/Web/CSS/border-width)." +
+            "Therefore this function still can be used without specifying parameter names. Replacement is not necessary." +
+            " It'll remain Deprecated until 2.0, and in 2.0 parameter names should be changed to: " +
+            "`vertical: CSSNumeric` and `horizontal: CSSNumeric`",
+    replaceWith = ReplaceWith(
+        expression = "borderWidth2(vertical = topLeft, horizontal = bottomRight)"
+    )
+)
 fun StyleScope.borderWidth(topLeft: CSSNumeric, bottomRight: CSSNumeric) {
-    property("border-width", "$topLeft $bottomRight")
+    borderWidth2(topLeft, bottomRight)
 }
 
+/**
+ * This function is a temporary replacement for `borderWidth(topLeft: CSSNumeric, bottomRight: CSSNumeric)`.
+ * After a fix for parameters names in `borderWidth`,
+ * this function will be Deprecated with a replaceWith `borderWidth`. Later `borderWidth2` will be Removed.
+ * @see borderWidth
+ */
+fun StyleScope.borderWidth2(vertical: CSSNumeric, horizontal: CSSNumeric) {
+    property("border-width", "$vertical $horizontal")
+}
+
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/border-width
+ *
+ * First argument sets the top border width.
+ * Second argument sets the horizontal borders width.
+ * Third argument sets the bottom border width.
+ *
+ * NOTE: Temporary deprecation until 2.0 because of wrong parameters names.
+ * In 2.0 the parameter names should be fixed. Despite the wrong parameter names, the function behaves correctly.
+ */
+@Deprecated(
+    message = "This function has misleading parameter names. " +
+            "Despite that, it behaves correctly (see https://developer.mozilla.org/en-US/docs/Web/CSS/border-width)." +
+            "Therefore this function still can be used without specifying parameter names. Replacement is not necessary." +
+            " It'll remain Deprecated until 2.0, and in 2.0 parameter names should be changed to: " +
+            "`top: CSSNumeric`, `horizontal: CSSNumeric`, `bottom: CSSNumeric`",
+    replaceWith = ReplaceWith(
+        expression = "borderWidth3(top = topLeft, horizontal = topRightAndBottomLeft, bottom = bottomRight)"
+    )
+)
 fun StyleScope.borderWidth(
     topLeft: CSSNumeric,
     topRightAndBottomLeft: CSSNumeric,
     bottomRight: CSSNumeric
 ) {
-    property("border-width", "$topLeft $topRightAndBottomLeft $bottomRight")
+    borderWidth3(topLeft, topRightAndBottomLeft, bottomRight)
 }
 
+/**
+ * This function is a temporary replacement for `borderWidth(topLeft: CSSNumeric, topRightAndBottomLeft: CSSNumeric, bottomRight: CSSNumeric)`.
+ * After a fix for parameters names in `borderWidth`,
+ * this function will be Deprecated with a replaceWith `borderWidth`. Later `borderWidth3` will be Removed.
+ * @see borderWidth
+ */
+fun StyleScope.borderWidth3(top: CSSNumeric, horizontal: CSSNumeric, bottom: CSSNumeric) {
+    property("border-width", "$top $horizontal $bottom")
+}
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/border-width
+ *
+ * First argument sets the top border width.
+ * Second argument sets the right border width.
+ * Third argument sets the bottom border width.
+ * Fourth argument sets the left border width.
+ *
+ * NOTE: Temporary deprecation until 2.0 because of wrong parameters names.
+ * In 2.0 the parameter names should be fixed. Despite the wrong parameter names, the function behaves correctly.
+ */
+@Deprecated(
+    message = "This function has misleading parameter names. " +
+            "Despite that, it behaves correctly (see https://developer.mozilla.org/en-US/docs/Web/CSS/border-width)." +
+            "Therefore this function still can be used without specifying parameter names. Replacement is not necessary." +
+            " It'll remain Deprecated until 2.0, and in 2.0 parameter names should be changed to: " +
+            "`top: CSSNumeric`, `right: CSSNumeric`, `bottom: CSSNumeric`, `left: CSSNumeric`",
+    replaceWith = ReplaceWith(
+        expression = "borderWidth4(top = topLeft, right = topRight, bottom = bottomRight, left = bottomLeft)"
+    )
+)
 fun StyleScope.borderWidth(
     topLeft: CSSNumeric,
     topRight: CSSNumeric,
     bottomRight: CSSNumeric,
     bottomLeft: CSSNumeric
 ) {
-    property(
-        "border-width",
-        "$topLeft $topRight $bottomRight $bottomLeft"
-    )
+    borderWidth4(topLeft, topRight, bottomRight, bottomLeft)
+}
+
+/**
+ * This function is a temporary replacement for `borderWidth(topLeft: CSSNumeric, topRight: CSSNumeric, bottomRight: CSSNumeric, bottomLeft: CSSNumeric)`.
+ * After a fix for parameters names in `borderWidth`,
+ * this function will be Deprecated with a replaceWith `borderWidth`. Later `borderWidth4` will be Removed.
+ * @see borderWidth
+ */
+fun StyleScope.borderWidth4(top: CSSNumeric, right: CSSNumeric, bottom: CSSNumeric, left: CSSNumeric) {
+    property("border-width", "$top $right $bottom $left")
 }


### PR DESCRIPTION
The reason is wrong parameter names. The behaviour is still correct. The idea is to fix the parameter names in 2.0 (which is more appropriate for breaking changes)

This PR is an alternative for https://github.com/JetBrains/compose-jb/pull/1982 