### PR TITLE
Add NO_SKIKO platforms set in ComposePlatforms

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -28,7 +28,7 @@ val mainComponents =
         ComposeComponent(":compose:material3:material3"),
         ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
-        ComposeComponent(":compose:runtime:runtime"),
+        ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:runtime:runtime-saveable"),
         ComposeComponent(":compose:ui:ui"),
         ComposeComponent(":compose:ui:ui-geometry"),

--- a/compose/buildSrc/src/main/kotlin/ComposeComponent.kt
+++ b/compose/buildSrc/src/main/kotlin/ComposeComponent.kt
@@ -5,5 +5,5 @@
 
 data class ComposeComponent(
     val path: String,
-    val supportedPlatforms: Set<ComposePlatforms> = ComposePlatforms.ALL
+    val supportedPlatforms: Set<ComposePlatforms> = ComposePlatforms.ALL - ComposePlatforms.NO_SKIKO
 )

--- a/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -15,7 +15,18 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
     MacosArm64("Macos"),
     UikitX64("UiKit"),
     UikitArm64("UiKit"),
-    UikitSimArm64("UiKit");
+    UikitSimArm64("UiKit"),
+    TvosArm64("TvOs"),
+    TvosX64("TvOs"),
+    TvosSimulatorArm64("TvOs"),
+    WatchosArm64("WatchOs"),
+    WatchosArm32("WatchOs"),
+    WatchosX86("WatchOs"),
+    WatchosX64("WatchOs"),
+    WatchosSimulatorArm64("WatchOs"),
+    LinuxX64("Linux"),
+    MingwX64("Mingw"),
+    ;
 
     fun matches(nameCandidate: String): Boolean =
         listOf(name, *alternativeNames).any { it.equals(nameCandidate, ignoreCase = true) }
@@ -32,6 +43,20 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
         val ANDROID = EnumSet.of(
             ComposePlatforms.AndroidDebug,
             ComposePlatforms.AndroidRelease
+        )
+
+        // Thses platforms are not supported by skiko yet
+        val NO_SKIKO = EnumSet.of(
+            ComposePlatforms.TvosArm64,
+            ComposePlatforms.TvosX64,
+            ComposePlatforms.TvosSimulatorArm64,
+            ComposePlatforms.WatchosArm64,
+            ComposePlatforms.WatchosArm32,
+            ComposePlatforms.WatchosX86,
+            ComposePlatforms.WatchosX64,
+            ComposePlatforms.WatchosSimulatorArm64,
+            ComposePlatforms.LinuxX64,
+            ComposePlatforms.MingwX64,
         )
 
         /**

--- a/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -45,7 +45,7 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.AndroidRelease
         )
 
-        // Thses platforms are not supported by skiko yet
+        // These platforms are not supported by skiko yet
         val NO_SKIKO = EnumSet.of(
             ComposePlatforms.TvosArm64,
             ComposePlatforms.TvosX64,


### PR DESCRIPTION
They can be used to build and publish compose-runtime. Other compose modules can't be built for NO_SKIKO since those platforms are not supported by skiko yet.

Related: https://github.com/JetBrains/androidx/pull/292 (adding more targets for compose-runtime in androidx fork)