### PR TITLE
Fix idea plugin compatability

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -57,7 +57,6 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set(projectProperties.pluginSinceBuild)
-        untilBuild.set(projectProperties.pluginUntilBuild)
     }
 
     runPluginVerifier {
@@ -72,7 +71,6 @@ class ProjectProperties(private val project: Project) {
     val platformDownloadSources get() = stringProperty("platform.download.sources").toBoolean()
     val pluginChannels get() = listProperty("plugin.channels")
     val pluginSinceBuild get() = stringProperty("plugin.since.build")
-    val pluginUntilBuild get() = stringProperty("plugin.until.build")
     val pluginVerifierIdeVersions get() = listProperty("plugin.verifier.ide.versions")
 
     private fun stringProperty(key: String): String =

--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -57,6 +57,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set(projectProperties.pluginSinceBuild)
+        untilBuild.set(projectProperties.pluginUntilBuild)
     }
 
     runPluginVerifier {
@@ -71,6 +72,7 @@ class ProjectProperties(private val project: Project) {
     val platformDownloadSources get() = stringProperty("platform.download.sources").toBoolean()
     val pluginChannels get() = listProperty("plugin.channels")
     val pluginSinceBuild get() = stringProperty("plugin.since.build")
+    val pluginUntilBuild get() = stringProperty("plugin.until.build")
     val pluginVerifierIdeVersions get() = listProperty("plugin.verifier.ide.versions")
 
     private fun stringProperty(key: String): String =

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -6,9 +6,8 @@ deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
 plugin.since.build=203
-plugin.until.build=222.*
 ## See https://jb.gg/intellij-platform-builds-list for available build versions.
-plugin.verifier.ide.versions=2020.3.2, 2021.1, 2022.1
+plugin.verifier.ide.versions=2020.3.2, 2021.1, 2022.1, 2022.2
 
 platform.type=IC
 platform.version=2021.1

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -6,9 +6,9 @@ deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
 plugin.since.build=203
-plugin.until.build=222.*
+plugin.until.build=223.*
 ## See https://jb.gg/intellij-platform-builds-list for available build versions.
-plugin.verifier.ide.versions=2020.3.2, 2021.1, 2022.1
+plugin.verifier.ide.versions=2021.1, 2022.1, 2022.2
 
 platform.type=IC
 platform.version=2021.1

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -6,8 +6,9 @@ deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
 plugin.since.build=203
+plugin.until.build=222.*
 ## See https://jb.gg/intellij-platform-builds-list for available build versions.
-plugin.verifier.ide.versions=2020.3.2, 2021.1, 2022.1, 2022.2
+plugin.verifier.ide.versions=2020.3.2, 2021.1, 2022.1
 
 platform.type=IC
 platform.version=2021.1

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -6,7 +6,6 @@ deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
 plugin.since.build=203
-plugin.until.build=223.*
 ## See https://jb.gg/intellij-platform-builds-list for available build versions.
 plugin.verifier.ide.versions=2021.1, 2022.1, 2022.2
 

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -6,6 +6,7 @@ deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
 plugin.since.build=203
+plugin.until.build=233.*
 ## See https://jb.gg/intellij-platform-builds-list for available build versions.
 plugin.verifier.ide.versions=2021.1, 2022.1, 2022.2
 


### PR DESCRIPTION
IDEA doesn't provide backward compatibility policy, and breaking changes can happen in any version, without prior deprecation:

https://plugins.jetbrains.com/docs/intellij/api-changes-list.html

~~Because of that, we can't remove `plugin.until.build`, and have to build Compose plugin for each new version of IDEA separately~~ (see Update)

~~Update 1:
I removed plugin.until.build anyway. In most cases there won't be a broken plugin. And if it will be broken, we will know it during IDEA EAP. Considering this, better when users don't wait the new version, and use already available one.~~

Update 2:
If we omit plugin.until.build, then it has default value +8. Returned, but made the default value big enough.

What we should do after that commit, is make sure, that we don't forget to check this compatibility. And ship a new stable version for every new stable IDEA.

The ideal way is to run `runPluginVerifier` on CI for the latest version, which will fail the build, if our plugin isn't compatible.

But for some reason, there is no EAP for IDEA 2022.3 here:
https://jb.gg/intellij-platform-builds-list

