### PR TITLE
Fix Todo example

### DIFF
--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -20,8 +20,9 @@ object Deps {
             val testAnnotationsCommon get() = "org.jetbrains.kotlin:kotlin-test-annotations-common:$VERSION"
         }
 
-        object Kotlinx {
-            val coroutinesSwing get() = "org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.6.4"
+        object Coroutines {
+            private val VERSION get() = "1.6.4"
+            val swing get() = "org.jetbrains.kotlinx:kotlinx-coroutines-swing:$VERSION"
         }
 
         object Compose {

--- a/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
+++ b/examples/todoapp/buildSrc/buildSrc/src/main/kotlin/Deps.kt
@@ -20,6 +20,10 @@ object Deps {
             val testAnnotationsCommon get() = "org.jetbrains.kotlin:kotlin-test-annotations-common:$VERSION"
         }
 
+        object Kotlinx {
+            val coroutinesSwing get() = "org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.6.4"
+        }
+
         object Compose {
             private val VERSION get() = properties["compose.version"]
             val gradlePlugin get() = "org.jetbrains.compose:compose-gradle-plugin:$VERSION"

--- a/examples/todoapp/desktop/build.gradle.kts
+++ b/examples/todoapp/desktop/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
                 implementation(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
                 implementation(Deps.Badoo.Reaktive.reaktive)
                 implementation(Deps.Badoo.Reaktive.coroutinesInterop)
+                implementation(Deps.JetBrains.Kotlinx.coroutinesSwing)
             }
         }
     }

--- a/examples/todoapp/desktop/build.gradle.kts
+++ b/examples/todoapp/desktop/build.gradle.kts
@@ -18,13 +18,13 @@ kotlin {
                 implementation(project(":common:database"))
                 implementation(project(":common:root"))
                 implementation(project(":common:compose-ui"))
+                implementation(Deps.JetBrains.Coroutines.swing)
                 implementation(Deps.ArkIvanov.Decompose.decompose)
                 implementation(Deps.ArkIvanov.Decompose.extensionsCompose)
                 implementation(Deps.ArkIvanov.MVIKotlin.mvikotlin)
                 implementation(Deps.ArkIvanov.MVIKotlin.mvikotlinMain)
                 implementation(Deps.Badoo.Reaktive.reaktive)
                 implementation(Deps.Badoo.Reaktive.coroutinesInterop)
-                implementation(Deps.JetBrains.Kotlinx.coroutinesSwing)
             }
         }
     }


### PR DESCRIPTION
In 1.1.1 we removed `Dispatchers.Main` from dependencies, because Compose can be embedded into different platforms with their own `Dispatchers.Main` (IDEA, for example).

Because of that, end applications should include it explicitly if they want to use it.

Now we have a crash in TODO at the start, because there is no `Dispatchers.Main`