### PR TITLE
Fix `kotlinCompilerPlugin` property

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/ComposeCompilerArtifactProvider.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/ComposeCompilerArtifactProvider.kt
@@ -6,6 +6,7 @@
 package org.jetbrains.compose.internal
 
 import org.jetbrains.compose.ComposeCompilerCompatability
+import org.jetbrains.compose.internal.ComposeCompilerArtifactProvider.DefaultCompiler.pluginArtifact
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
@@ -15,7 +16,7 @@ private const val KOTLIN_COMPATABILITY_LINK =
 
 internal class ComposeCompilerArtifactProvider(
     private val kotlinVersion: String,
-    customPluginString: () -> String?
+    private val customPluginString: () -> String?
 ) {
     fun checkTargetSupported(target: KotlinTarget) {
         require(!unsupportedPlatforms.contains(target.platformType)) {
@@ -26,35 +27,28 @@ internal class ComposeCompilerArtifactProvider(
         }
     }
 
-    private var unsupportedPlatforms: Set<KotlinPlatformType> = emptySet()
+    private val autoCompilerVersion by lazy {
+        requireNotNull(
+            ComposeCompilerCompatability.compilerVersionFor(kotlinVersion)
+        ) {
+            "This version of Compose Multiplatform doesn't support Kotlin " +
+                    "$kotlinVersion. " +
+                    "Please see $KOTLIN_COMPATABILITY_LINK " +
+                    "to know the latest supported version of Kotlin."
+        }
+    }
 
-    val compilerArtifact: SubpluginArtifact
-
-    init {
+    private val customCompilerArtifact: SubpluginArtifact? by lazy {
         val customPlugin = customPluginString()
         val customCoordinates = customPlugin?.split(":")
         when (customCoordinates?.size) {
-            null -> {
-                val version = requireNotNull(
-                    ComposeCompilerCompatability.compilerVersionFor(kotlinVersion)
-                ) {
-                    "This version of Compose Multiplatform doesn't support Kotlin " +
-                        "$kotlinVersion. " +
-                        "Please see $KOTLIN_COMPATABILITY_LINK " +
-                        "to know the latest supported version of Kotlin."
-                }
-
-                compilerArtifact = DefaultCompiler.pluginArtifact(
-                    version = version.version
-                )
-                unsupportedPlatforms = version.unsupportedPlatforms
-            }
+            null -> null
             1 -> {
                 val customVersion = customCoordinates[0]
                 check(customVersion.isNotBlank()) { "'compose.kotlinCompilerPlugin' cannot be blank!" }
-                compilerArtifact = DefaultCompiler.pluginArtifact(version = customVersion)
+                pluginArtifact(version = customVersion)
             }
-            3 -> compilerArtifact = DefaultCompiler.pluginArtifact(
+            3 -> pluginArtifact(
                 version = customCoordinates[2],
                 groupId = customCoordinates[0],
                 artifactId = customCoordinates[1],
@@ -65,6 +59,14 @@ internal class ComposeCompilerArtifactProvider(
                         Actual value: '$customPlugin'
                 """.trimIndent())
         }
+    }
+
+    private val unsupportedPlatforms: Set<KotlinPlatformType> by lazy {
+        if (customCompilerArtifact == null) autoCompilerVersion.unsupportedPlatforms else emptySet()
+    }
+
+    val compilerArtifact: SubpluginArtifact get() {
+        return customCompilerArtifact ?: pluginArtifact(version = autoCompilerVersion.version)
     }
 
     val compilerHostedArtifact: SubpluginArtifact

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/ComposeCompilerArtifactProvider.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/internal/ComposeCompilerArtifactProvider.kt
@@ -62,7 +62,7 @@ internal class ComposeCompilerArtifactProvider(
     }
 
     private val unsupportedPlatforms: Set<KotlinPlatformType> by lazy {
-        if (customCompilerArtifact == null) autoCompilerVersion.unsupportedPlatforms else emptySet()
+        if (customCompilerArtifact != null) emptySet() else autoCompilerVersion.unsupportedPlatforms
     }
 
     val compilerArtifact: SubpluginArtifact get() {

--- a/gradle-plugins/gradle.properties
+++ b/gradle-plugins/gradle.properties
@@ -12,8 +12,8 @@ compose.tests.js.compiler.compatible.kotlin.version=1.7.10
 # Version of Compose Compiler published by Google.
 # Used to check if our plugin is compatible with it.
 # https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-compose.tests.androidx.compiler.version=1.3.1
-compose.tests.androidx.compiler.compatible.kotlin.version=1.7.10
+compose.tests.androidx.compiler.version=1.1.1
+compose.tests.androidx.compiler.compatible.kotlin.version=1.6.10
 
 # A version of Gradle plugin, that will be published,
 # unless overridden by COMPOSE_GRADLE_PLUGIN_VERSION env var.


### PR DESCRIPTION
[Support multiple versions of Kotlin PR](https://github.com/JetBrains/compose-jb/pull/2366) breaks `kotlinCompilerPlugin` feature.

`customPluginString` isn't set at the moment of plugin applying (or Provider's initialization), so we need to read it only when the artifact is requested.