### PR TITLE
README.md build Compose to mavenLocal

### DIFF
--- a/compose/README.md
+++ b/compose/README.md
@@ -76,14 +76,13 @@ Run native macos sample:
 ./scripts/runGradle runMppMacos
 ```
 
-## Multiplatform build
+## Multiplatform build to mavenLocal
 
-```console
-./compose/frameworks/support/jbdeps/android-sdk/downloadAndroidSdk
-export COMPOSE_CUSTOM_VERSION=1.1.0-beta04
-./scripts/publishToMavenLocal -Pcompose.platforms=all
-./scripts/publishGradlePluginToMavenLocal
+```bash
+export COMPOSE_CUSTOM_VERSION=0.0.0-custom-version &&\
+./scripts/publishToMavenLocal -Pcompose.platforms=all &&\
+./scripts/publishGradlePluginToMavenLocal &&\
 ./scripts/publishWebComponentsToMavenLocal
 ```
-`-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,uikitx64`.
+`-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,uikit`.
 


### PR DESCRIPTION
Now script to build to mavenLocal can be launched from README
<img width="508" alt="image" src="https://user-images.githubusercontent.com/99798741/195593333-64807187-e730-4b56-bd7c-a22712788f03.png">
