### PR TITLE
Use Compose Compiler 1.3.2.1

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatability.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatability.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 internal object ComposeCompilerCompatability {
     fun compilerVersionFor(kotlinVersion: String): ComposeCompilerVersion? = when (kotlinVersion) {
         "1.7.10" -> ComposeCompilerVersion("1.3.0")
-        "1.7.20" -> ComposeCompilerVersion("1.3.2.1-rc01")
+        "1.7.20" -> ComposeCompilerVersion("1.3.2.1-rc02")
         else -> null
     }
 }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatability.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposeCompilerCompatability.kt
@@ -5,10 +5,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 internal object ComposeCompilerCompatability {
     fun compilerVersionFor(kotlinVersion: String): ComposeCompilerVersion? = when (kotlinVersion) {
         "1.7.10" -> ComposeCompilerVersion("1.3.0")
-        "1.7.20" -> ComposeCompilerVersion(
-            "1.3.2",
-            unsupportedPlatforms = setOf(KotlinPlatformType.js)
-        )
+        "1.7.20" -> ComposeCompilerVersion("1.3.2.1-rc01")
         else -> null
     }
 }


### PR DESCRIPTION
With Kotlin 1.7.20 support for JS

Gradle plugin tests work.

Will also test on Compose Multiplatform `1.2.1-rc01`, and then we can build Compose Compiler `1.3.2.1`