### PR TITLE
Describe workaround with Tab navigation and multiline TextField's

### DIFF
--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -309,3 +309,54 @@ fun main() = application {
 ```
 
 <img alt="reverse-order" src="focus-switcher.gif" height="480" />
+
+## Known problems
+
+### Tab key navigation work's bad with multiline TextField
+```Kotlin
+Column(
+    modifier = Modifier.padding(50.dp)
+) {
+    for (x in 1..5) {
+        val text = remember { mutableStateOf("") }
+        OutlinedTextField(
+            value = text.value,
+            singleLine = false, // Make attention here! Also by default singleLine is false.
+            onValueChange = { text.value = it }
+        )
+    }
+}
+```
+When User press 'Tab' key, navigation not performs, and adding tab character to text value.
+
+#### Possible workaround:
+
+This workaround mentioned in [Issues/109](https://github.com/JetBrains/compose-jb/issues/109#issuecomment-1161705265)
+
+```Kotlin
+OutlinedTextField(
+    value = text.value,
+    singleLine = false,
+    onValueChange = { text.value = it },
+    modifier = Modifier.moveFocusOnTab()
+)
+```
+
+And function moveFocusOnTab():
+
+```Kotlin
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun Modifier.moveFocusOnTab(
+    focusManager: FocusManager = LocalFocusManager.current
+) = onPreviewKeyEvent {
+        if (it.type == KeyEventType.KeyDown && it.key == Key.Tab) {
+            focusManager.moveFocus(
+                if (it.isShiftPressed) FocusDirection.Previous
+                else FocusDirection.Next
+            )
+            return@onPreviewKeyEvent true
+        }
+        false
+    }
+```

--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -327,7 +327,7 @@ Column(
     }
 }
 ```
-When User press 'Tab' key, navigation not performs, and adding tab character to text value.
+When the user presses the 'Tab' key, the focus doesn't switch to the next focusable component. Instead the Tab character is added.
 
 #### Possible workaround:
 

--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -312,7 +312,7 @@ fun main() = application {
 
 ## Known problems
 
-### Tab key navigation work's bad with multiline TextField
+### Tab key navigation doesn't work in a multiline TextField
 ```Kotlin
 Column(
     modifier = Modifier.padding(50.dp)

--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -313,7 +313,7 @@ fun main() = application {
 ## Known problems
 
 ### Tab key navigation doesn't work in a multiline TextField
-```Kotlin
+``` Kotlin
 Column(
     modifier = Modifier.padding(50.dp)
 ) {

--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -329,7 +329,7 @@ Column(
 ```
 When the user presses the 'Tab' key, the focus doesn't switch to the next focusable component. Instead the Tab character is added.
 
-#### Possible workaround:
+#### A possible workaround
 
 This workaround mentioned in [Issues/109](https://github.com/JetBrains/compose-jb/issues/109#issuecomment-1161705265)
 

--- a/tutorials/Tab_Navigation/README.md
+++ b/tutorials/Tab_Navigation/README.md
@@ -331,7 +331,7 @@ When the user presses the 'Tab' key, the focus doesn't switch to the next focusa
 
 #### A possible workaround
 
-This workaround mentioned in [Issues/109](https://github.com/JetBrains/compose-jb/issues/109#issuecomment-1161705265)
+This workaround is mentioned in [Issues/109](https://github.com/JetBrains/compose-jb/issues/109#issuecomment-1161705265).
 
 ```Kotlin
 OutlinedTextField(


### PR DESCRIPTION
Our user made workaround for Tab navigation bug with multiline TextFields:
https://github.com/JetBrains/compose-jb/issues/109#issuecomment-1325246518