### PR TITLE
Remove JVM target version override

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -68,17 +68,6 @@ class ComposePlugin : Plugin<Project> {
                     it.replacedBy(replacement, "org.jetbrains.compose isn't compatible with androidx.compose, because it is the same library published with different maven coordinates")
                 }
             }
-
-            val overrideDefaultJvmTarget = ComposeProperties.overrideKotlinJvmTarget(project.providers).get()
-            project.tasks.withType(KotlinCompile::class.java) {
-                it.kotlinOptions.apply {
-                    if (overrideDefaultJvmTarget) {
-                        if (jvmTarget.isNullOrBlank() || jvmTarget.toDouble() < 1.8) {
-                             jvmTarget = "1.8"
-                         }
-                    }
-                }
-            }
         }
     }
 

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/ComposeProjectProperties.kt
@@ -10,7 +10,6 @@ import org.gradle.api.provider.ProviderFactory
 
 internal object ComposeProperties {
     internal const val VERBOSE = "compose.desktop.verbose"
-    internal const val OVERRIDE_KOTLIN_JVM_TARGET = "compose.desktop.override.default.kotlin.jvm.target"
     internal const val PRESERVE_WD = "compose.preserve.working.dir"
     internal const val MAC_SIGN = "compose.desktop.mac.sign"
     internal const val MAC_SIGN_ID = "compose.desktop.mac.signing.identity"
@@ -22,11 +21,6 @@ internal object ComposeProperties {
 
     fun isVerbose(providers: ProviderFactory): Provider<Boolean> =
         providers.findProperty(VERBOSE).toBoolean()
-
-    fun overrideKotlinJvmTarget(providers: ProviderFactory): Provider<Boolean> =
-        providers.provider {
-            providers.findProperty(OVERRIDE_KOTLIN_JVM_TARGET)?.toString() != "false"
-        }
 
     fun preserveWorkingDir(providers: ProviderFactory): Provider<Boolean> =
         providers.findProperty(PRESERVE_WD).toBoolean()

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/tests/integration/DesktopApplicationTest.kt
@@ -153,8 +153,14 @@ class DesktopApplicationTest : GradlePluginTestBase() {
         testPackageJvmDistributions()
     }
 
+
     private fun TestProject.testPackageJvmDistributions() {
         val result = gradle(":packageDistributionForCurrentOS").build()
+
+        val mainClass = file("build/classes").walk().single { it.isFile && it.name == "MainKt.class" }
+        val bytecodeVersion = readClassFileVersion(mainClass)
+        assertEquals(JDK_11_BYTECODE_VERSION, bytecodeVersion, "$mainClass bytecode version")
+
         val ext = when (currentOS) {
             OS.Linux -> "deb"
             OS.Windows -> "msi"

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/jdkUtls.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/jdkUtls.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020-2022 JetBrains s.r.o. and respective authors and developers.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE.txt file.
+ */
+
+package org.jetbrains.compose.test.utils
+
+import java.io.File
+
+const val JDK_11_BYTECODE_VERSION = 55
+
+fun readClassFileVersion(classFile: File): Int {
+    val url = classFile.toURI().toURL().toExternalForm()
+    val javapResult = runJavaTool("javap", "-verbose", url)
+    val majorVersionRegex = "major version: (\\d+)".toRegex()
+    val bytecode = javapResult.out
+    val match = majorVersionRegex.find(bytecode)
+        ?: error(buildString {
+            appendLine("Could not find 'major version' in '$classFile' bytecode:")
+            appendLine(bytecode)
+        })
+    return match.groupValues[1].toInt()
+}
+
+fun runJavaTool(toolName: String, vararg args: String): ProcessRunResult {
+    val javaHome = File(System.getProperty("java.home"))
+    val toolExecutableName = if (isWindows) "$toolName.exe" else toolName
+    val executable = javaHome.resolve("bin/$toolExecutableName")
+    check(executable.isFile) { "Could not find tool '$toolName' at specified path: $executable" }
+    return runProcess(executable, args.toList())
+}

--- a/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/processUtils.kt
+++ b/gradle-plugins/compose/src/test/kotlin/org/jetbrains/compose/test/utils/processUtils.kt
@@ -7,9 +7,9 @@ package org.jetbrains.compose.test.utils
 
 import java.io.File
 
-internal data class ProcessRunResult(val exitCode: Int, val out: String, val err: String)
+data class ProcessRunResult(val exitCode: Int, val out: String, val err: String)
 
-internal fun runProcess(
+fun runProcess(
     tool: File,
     args: Collection<String>,
     checkExitCodeIsNormal: Boolean = true
@@ -47,3 +47,5 @@ internal fun runProcess(
         errFile.delete()
     }
 }
+
+val isWindows = System.getProperty("os.name").contains("windows", ignoreCase = true)

--- a/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/jvm/build.gradle
@@ -14,6 +14,12 @@ dependencies {
     implementation compose.desktop.currentOs
 }
 
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 compose.desktop {
     application {
         mainClass = "MainKt"

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/build.gradle
@@ -37,6 +37,14 @@ android {
     }
 }
 
+kotlin {
+    jvm {
+        jvmToolchain {
+            languageVersion.set(JavaLanguageVersion.of(11))
+        }
+    }
+}
+
 compose.desktop {
     application {
         mainClass = "MainKt"

--- a/gradle-plugins/compose/src/test/test-projects/application/mpp/settings.gradle
+++ b/gradle-plugins/compose/src/test/test-projects/application/mpp/settings.gradle
@@ -10,4 +10,4 @@ pluginManagement {
         google()
     }
 }
-rootProject.name = "simple"
+rootProject.name = "mpp"


### PR DESCRIPTION
Previously, we were setting kotlin.jvmTarget version to 1.8 if it was null or < 1.8.
As an unintended consequence we were also overriding a version set by the jvmToolchain property.
So while users expected the jvmToolchain property
to set both jdk home & jdk target, we were quietly overriding jdk target.

At the same time, Kotlin 1.7 sets the minimum
target version to 1.8 anyway, so our override
does not make sense with Kotlin 1.7+.

This commit removes overriding altogether.

Fixes #2511