### PR TITLE
Fix examples with Kotlin Native

### DIFF
--- a/examples/codeviewer/build.gradle.kts
+++ b/examples/codeviewer/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/examples/imageviewer/build.gradle.kts
+++ b/examples/imageviewer/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/examples/issues/build.gradle.kts
+++ b/examples/issues/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/examples/todoapp-lite/build.gradle.kts
+++ b/examples/todoapp-lite/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/examples/widgets-gallery/build.gradle.kts
+++ b/examples/widgets-gallery/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/experimental/examples/codeviewer/build.gradle.kts
+++ b/experimental/examples/codeviewer/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/experimental/examples/falling-balls-mpp/build.gradle.kts
+++ b/experimental/examples/falling-balls-mpp/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/experimental/examples/imageviewer/build.gradle.kts
+++ b/experimental/examples/imageviewer/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/experimental/examples/todoapp-lite/build.gradle.kts
+++ b/experimental/examples/todoapp-lite/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()

--- a/experimental/examples/widgets-gallery/build.gradle.kts
+++ b/experimental/examples/widgets-gallery/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     id("org.jetbrains.compose") apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
After slack discussion https://kotlinlang.slack.com/archives/C0346LWVBJ4/p1669909609277119
We notice what `subprojects` better change to `allprojects`. It helps to open and run on AndroidStudio.

Kotlin Native need mavenCentral at root build.gradle.kts