### PR TITLE
improve ExperimentalUnpackSkikoWasmRuntimeTask Gradle Config Cache compatibility

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
@@ -5,6 +5,7 @@
 
 package org.jetbrains.compose.experimental.web.tasks
 
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
@@ -8,7 +8,9 @@ package org.jetbrains.compose.experimental.web.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
@@ -14,7 +14,10 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.jetbrains.compose.internal.debug
 
-abstract class ExperimentalUnpackSkikoWasmRuntimeTask : DefaultTask() {
+abstract class ExperimentalUnpackSkikoWasmRuntimeTask @Inject constructor(
+    val files: FileSystemOperations,
+    val archives: ArchiveOperations,
+): DefaultTask() {
     @get:InputFiles
     lateinit var runtimeClasspath: Configuration
 
@@ -23,8 +26,6 @@ abstract class ExperimentalUnpackSkikoWasmRuntimeTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        project.delete(outputDir)
-        project.mkdir(outputDir)
         val runtimeArtifacts = runtimeClasspath.resolvedConfiguration.resolvedArtifacts
         for (artifact in runtimeArtifacts) {
             logger.debug { "Checking artifact: id=${artifact.id}, file=${artifact.file}" }
@@ -43,8 +44,8 @@ abstract class ExperimentalUnpackSkikoWasmRuntimeTask : DefaultTask() {
 
         for (file in skikoRuntimeConfig.resolve()) {
             if (file.name.endsWith(".jar", ignoreCase = true)) {
-                project.copy { copySpec ->
-                    copySpec.from(project.zipTree(file))
+                files.sync { copySpec ->
+                    copySpec.from(archives.zipTree(file))
                     copySpec.into(outputDir)
                 }
             }

--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/experimental/web/tasks/ExperimentalUnpackSkikoWasmRuntimeTask.kt
@@ -18,8 +18,8 @@ import org.gradle.api.tasks.TaskAction
 import org.jetbrains.compose.internal.debug
 
 abstract class ExperimentalUnpackSkikoWasmRuntimeTask @Inject constructor(
-    val files: FileSystemOperations,
-    val archives: ArchiveOperations,
+    private val files: FileSystemOperations,
+    private val archives: ArchiveOperations,
 ): DefaultTask() {
     @get:InputFiles
     lateinit var runtimeClasspath: Configuration


### PR DESCRIPTION
partially fixes #2587, but does not fix the `project.configurations`, which requires more work.