### PR TITLE
Improve documentation for signing on macOS

### DIFF
--- a/tutorials/Signing_and_notarization_on_macOS/README.md
+++ b/tutorials/Signing_and_notarization_on_macOS/README.md
@@ -15,22 +15,22 @@ for distribution on macOS.
 * [Xcode](https://developer.apple.com/xcode/). The tutorial was checked with Xcode 12.3.
 * JDK 15+. The tutorial was checked with OpenJDK 15.0.1.
 
-## Preparing a Developer ID certificate
+## Preparing a certificate
 
-You will need a Developer ID certificate for signing your app.
+You will need a certificate for signing your app.
 
-#### Checking existing Developer ID certificates
+#### Checking existing certificates
 
 Open https://developer.apple.com/account/resources/certificates
 
-#### Creating a new Developer ID certificate
+#### Creating a new certificate
 1. [Create a certificate signing request](https://help.apple.com/developer-account/#/devbfa00fef7):
     * Open `Keychain Access`.
     * Open the menu dialog
         ```
         Keychain Access > Certificate Assistant > Request a Certificate from a Certificate Authority
         ```
-    * Enter your Developer ID email and common name.
+    * Enter your certificate email and common name.
     * Check `Save to disk` option.
 2. Create and install a new certificate using your [Apple Developer account](https://developer.apple.com/account/):
     * Open https://developer.apple.com/account/resources/certificates/add
@@ -104,7 +104,7 @@ Note that you need to create two of these profiles, one for your app and another
 ## Creating an app-specific password
 
 To be able to upload an app for notarization,
-you will need an app-specific password associated with your Apple ID.
+you will need an app-specific password associated with your Apple ID. Notarization is only required for apps outside the App Store.
 
 Follow these steps to generate a new password:
 1. Sign in to your [Apple ID](https://appleid.apple.com/account/home) account page.
@@ -222,6 +222,8 @@ The following Gradle properties can be used instead of DSL properties:
 Those properties could be stored in `$HOME/.gradle/gradle.properties` to use across multiple applications.
 
 ### Configuring notarization settings
+
+Notarization is only required for apps outside the App Store.
 
 ``` kotlin
 macOS {
@@ -369,9 +371,10 @@ Apple, and they may be able to give you a more detailed error message.
 ## Using Gradle
 
 The following tasks are available:
-* Use `createDistributable` or `packageDmg` to get a signed application
+* Use `createDistributable`, `packageDmg`, or `packagePkg` to get a signed application
   (no separate step is required).
-* Use `notarize<PACKAGING_FORMAT>` (e.g. `notarizeDmg`) to upload an application for notarization.
+* Use `notarize<PACKAGING_FORMAT>` (e.g. `notarizeDmg`) to upload an application for notarization. 
+  Notarization is only required for apps outside the App Store.
   Once the upload finishes, a `RequestUUID` will be printed. 
   The notarization process takes some time.
   Once the notarization process finishes, an email will be sent to you.

--- a/tutorials/Signing_and_notarization_on_macOS/README.md
+++ b/tutorials/Signing_and_notarization_on_macOS/README.md
@@ -24,7 +24,7 @@ You will need a certificate for signing your app.
 Open https://developer.apple.com/account/resources/certificates
 
 #### Creating a new certificate
-1. [Create a certificate signing request](https://help.apple.com/developer-account/#/devbfa00fef7):
+1. [Create a certificate signing request](https://developer.apple.com/help/account/create-certificates/create-a-certificate-signing-request):
     * Open `Keychain Access`.
     * Open the menu dialog
         ```


### PR DESCRIPTION
- Removed "Developer ID" as that certificate type is not actually used when following steps for App Store
- Added note that notarization will not work for the App Store
- Fixed a broken link