### PR TITLE
Fix running unsigned apps locally on macOS Ventura

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigningHelper.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/desktop/application/internal/MacSigningHelper.kt
@@ -7,9 +7,9 @@ package org.jetbrains.compose.desktop.application.internal
 
 import org.jetbrains.compose.desktop.application.internal.files.isDylibPath
 import java.io.File
+import java.nio.file.*
 import kotlin.io.path.isExecutable
 import kotlin.io.path.isRegularFile
-import kotlin.io.path.isSymbolicLink
 
 internal class MacSigningHelper(
     private val macSigner: MacSigner,
@@ -23,58 +23,18 @@ internal class MacSigningHelper(
     private val runtimeDir = appDir.resolve("Contents/runtime")
 
     fun modifyRuntimeIfNeeded() {
-        // Only resign modify the runtime if a provisioning profile or alternative entitlements file is provided.
-        // If no entitlements file is provided, the runtime cannot be resigned.
-        if (runtimeProvisioningProfile == null &&
-            // When resigning the runtime, an app entitlements file is also needed.
-            (runtimeEntitlementsFile == null || entitlementsFile == null)
-        ) {
-            return
-        }
 
-        // Add the provisioning profile
-        runtimeProvisioningProfile?.let {
-            addRuntimeProvisioningProfile(runtimeDir, it)
-        }
 
         // Resign the runtime completely (and also the app dir only)
-        resignRuntimeAndAppDir(appDir, runtimeDir)
-    }
-
-    private fun addRuntimeProvisioningProfile(
-        runtimeDir: File,
-        runtimeProvisioningProfile: File
-    ) {
-        runtimeProvisioningProfile.copyTo(
-            target = runtimeDir.resolve("Contents/embedded.provisionprofile"),
-            overwrite = true
-        )
-    }
-
-    private fun resignRuntimeAndAppDir(
-        appDir: File,
-        runtimeDir: File
-    ) {
         // Sign all libs and executables in runtime
         runtimeDir.walk().forEach { file ->
             val path = file.toPath()
-            if (path.isRegularFile() && (path.isExecutable() || path.toString().isDylibPath)) {
-                if (path.isSymbolicLink()) {
-                    // Ignore symbolic links
-                } else {
-                    // Resign file
-                    macSigner.unsign(file)
-                    macSigner.sign(file, runtimeEntitlementsFile)
-                }
+            if (path.isRegularFile(LinkOption.NOFOLLOW_LINKS) && (path.isExecutable() || file.name.isDylibPath)) {
+                macSigner.sign(file, runtimeEntitlementsFile)
             }
         }
 
-        // Resign runtime directory
-        macSigner.unsign(runtimeDir)
         macSigner.sign(runtimeDir, runtimeEntitlementsFile, forceEntitlements = true)
-
-        // Resign app directory (contents other than runtime were already signed by jpackage)
-        macSigner.unsign(appDir)
         macSigner.sign(appDir, entitlementsFile, forceEntitlements = true)
     }
 }


### PR DESCRIPTION
Normally macOS Gatekeeper does not allow unsigned apps to run. However, apps created on the same machine were allowed to run. This allows developers to test package apps on their machines without configuring Apple Developer ID.

Previously, the Compose Multiplatform Gradle plugin simply did not do anything, when the signing was not configured. However, in macOS Ventura the Gatekeeper checks
became stricker, so "unsigned" packaged apps started to be shown as "damaged".

This seems to happen, because parts of a final app image were signed. Also they were signed by different certificates (a runtime image could be signed by a runtime vendor, while Skiko binary is signed by JetBrains).

This change removes all signatures if signing is not configured.

See also https://bugs.openjdk.org/browse/JDK-8276150