### PR TITLE
Redo: set until-build to undefined value

### DIFF
--- a/idea-plugin/build.gradle.kts
+++ b/idea-plugin/build.gradle.kts
@@ -25,6 +25,7 @@ intellij {
     type.set(projectProperties.platformType)
     version.set(projectProperties.platformVersion)
     downloadSources.set(projectProperties.platformDownloadSources)
+    updateSinceUntilBuild.set(false)
 
     plugins.set(
         listOf(
@@ -55,10 +56,6 @@ tasks {
         channels.set(projectProperties.pluginChannels)
     }
 
-    patchPluginXml {
-        sinceBuild.set(projectProperties.pluginSinceBuild)
-    }
-
     runPluginVerifier {
         ideVersions.set(projectProperties.pluginVerifierIdeVersions)
     }
@@ -70,7 +67,6 @@ class ProjectProperties(private val project: Project) {
     val platformVersion get() = stringProperty("platform.version")
     val platformDownloadSources get() = stringProperty("platform.download.sources").toBoolean()
     val pluginChannels get() = listProperty("plugin.channels")
-    val pluginSinceBuild get() = stringProperty("plugin.since.build")
     val pluginVerifierIdeVersions get() = listProperty("plugin.verifier.ide.versions")
 
     private fun stringProperty(key: String): String =

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -5,8 +5,8 @@ kotlin.stdlib.default.dependency=false
 deploy.version=0.1-SNAPSHOT
 
 plugin.channels=snapshots
-plugin.since.build=213
-## See https://jb.gg/intellij-platform-builds-list for available build versions.
+# Intellij since-build should be updated directly in src/main/resources/META-INF/plugin.xml
+# See https://jb.gg/intellij-platform-builds-list for available build versions.
 plugin.verifier.ide.versions=2021.3, 2022.1, 2022.2
 
 platform.type=IC

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,9 @@
 
     </description>
 
+    <!-- until-build is omitted, so we don't have to update it after each Intellij release -->
+    <idea-version since-build="213"/>
+
     <!-- Product and plugin compatibility requirements -->
     <!-- https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
     <depends>com.intellij.modules.platform</depends>


### PR DESCRIPTION
Previously we unset until-build in DSL.
However, Intellij SDK Gradle plugin DSL
does not support setting only since-build,
while omitting until-build.

So we effectively made the plugin
compatible with a single version of Intellij.

This change fixes that by disabling patching
since-build/until-build from DSL and setting
since-build version directly in plugin.xml