### PR TITLE
add LinuxArm64 to ComposePlatforms + move compose submodule

### DIFF
--- a/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/compose/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -25,6 +25,7 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
     WatchosX64("WatchOs"),
     WatchosSimulatorArm64("WatchOs"),
     LinuxX64("Linux"),
+    LinuxArm64("Linux"),
     MingwX64("Mingw"),
     ;
 
@@ -56,6 +57,7 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.WatchosX64,
             ComposePlatforms.WatchosSimulatorArm64,
             ComposePlatforms.LinuxX64,
+            ComposePlatforms.LinuxArm64,
             ComposePlatforms.MingwX64,
         )
 


### PR DESCRIPTION
This will enable compose:runtime publication for linuxArm64

This is a follow up for https://github.com/JetBrains/androidx/pull/382