### PR TITLE
Gradle DSL: Fix kotlinCompilerPluginArgs missing multiplatform targets

### DIFF
--- a/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
+++ b/gradle-plugins/compose/src/main/kotlin/org/jetbrains/compose/ComposePlugin.kt
@@ -28,7 +28,7 @@ import org.jetbrains.compose.internal.utils.currentTarget
 import org.jetbrains.compose.web.WebExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 
 internal val composeVersion get() = ComposeBuildConfig.composeVersion
 


### PR DESCRIPTION
See https://github.com/JetBrains/compose-jb/issues/2459#issuecomment-1416179472