### PR TITLE
UIKit samples, change deprecated annotation @UIApplicationMain -> @main

### DIFF
--- a/components/resources/demo/iosApp/iosApp/iosApp.swift
+++ b/components/resources/demo/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/codeviewer/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/codeviewer/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/falling-balls-mpp/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/falling-balls-mpp/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/imageviewer/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/imageviewer/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/minesweeper/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/minesweeper/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/todoapp-lite/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/todoapp-lite/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/visual-effects/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/visual-effects/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 

--- a/experimental/examples/widgets-gallery/iosApp/iosApp/iosApp.swift
+++ b/experimental/examples/widgets-gallery/iosApp/iosApp/iosApp.swift
@@ -1,7 +1,7 @@
 import UIKit
 import shared
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 


### PR DESCRIPTION
Annotation `@UIApplicationMain` will be deprecated.
https://github.com/apple/swift-evolution/blob/main/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md