### PR TITLE
ImageViewer: Fix letter-spacing (override material design defaults back to 0.sp)

### DIFF
--- a/experimental/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/style/Palette.kt
+++ b/experimental/examples/imageviewer/shared/src/commonMain/kotlin/example/imageviewer/style/Palette.kt
@@ -1,10 +1,13 @@
 package example.imageviewer.style
 
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.sp
 
 object ImageviewerColors {
     val Gray = Color.DarkGray
@@ -53,6 +56,8 @@ internal fun ImageViewerTheme(content: @Composable () -> Unit) {
             onBackground = ImageviewerColors.onBackground
         )
     ) {
-        content()
+        ProvideTextStyle(LocalTextStyle.current.copy(letterSpacing = 0.sp)) {
+            content()
+        }
     }
 }


### PR DESCRIPTION
With the default Material Theme, the font (Inter) renders differently in Compose than it does in Chrome, for example. 

It becomes more apparent when you have more free-flowing text placed side-by-side (again Compose Desktop vs Chrome, both with Inter)

![image](https://user-images.githubusercontent.com/2178959/222932605-53536164-9345-446c-93c0-bea43379dd55.png)

After investigating some more, it seems I have found the culprit; for reasons unbeknownst to mankind, Material UI specifies a `letterSpacing = 0.5.dp` for all Text elements by default, which makes most regular fonts like Inter look all out of the regular. Here's a direct comparison between the default and injecting a `letterSpacing = 0.dp` via `ProvideTextStyle`:


https://user-images.githubusercontent.com/2178959/222932615-f4cf3143-1e94-4135-a795-8225f75d569a.mov

...now the text is exactly the same as it is rendered in Chrome (in this case, Inter), which I consider the "canonical" way of how the text should look :)

![image](https://user-images.githubusercontent.com/2178959/222932628-ba8e7b1c-500b-4a79-b75e-ab07527fc9c2.png)

(internal discussion: https://jetbrains.slack.com/archives/C015PT6ALK1/p1676936444752569)